### PR TITLE
Fix w.r.t. the master branches of Coq and MathComp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,16 @@ env:
   - NJOBS="2"
   - CONTRIB_NAME="real-closed"
   matrix:
-  - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.8"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.8"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.10"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.10.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.10.0-coq-8.10"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.7"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.8"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.9"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.10"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.11"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.7"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.8"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.9"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.10"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.11"
 
 install: |
   # Prepare the COQ container

--- a/opam
+++ b/opam
@@ -10,8 +10,8 @@ license: "CeCILL-B"
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.7" & < "8.11~") }
-  "coq-mathcomp-field"       {(>= "1.8.0" & <= "1.10.0")}
+  "coq" { (>= "8.7" & < "8.12~") | = "dev" }
+  "coq-mathcomp-field"       {(>= "1.11.0" & < "1.12~") | = "dev" }
   "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1~")}
 ]
 

--- a/theories/cauchyreals.v
+++ b/theories/cauchyreals.v
@@ -4,7 +4,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp
 Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp
-Require Import bigop ssralg ssrnum ssrint rat poly polydiv polyorder.
+Require Import bigop order ssralg ssrnum ssrint rat poly polydiv polyorder.
 From mathcomp
 Require Import perm matrix mxpoly polyXY binomial bigenough.
 
@@ -15,7 +15,7 @@ Require Import perm matrix mxpoly polyXY binomial bigenough.
 (*               cannot be equipped with any ssreflect algebraic structure *)
 (***************************************************************************)
 
-Import GRing.Theory Num.Theory Num.Def BigEnough.
+Import Order.TTheory GRing.Theory Num.Theory Num.Def BigEnough.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -70,7 +70,7 @@ Lemma poly_boundP p a r x : `|x - a| <= r ->
   `|p.[x]| <= poly_bound p a r.
 Proof.
 have [r_ge0|r_lt0] := lerP 0 r; last first.
-  by move=> hr; have := ler_lt_trans hr r_lt0; rewrite normr_lt0.
+  by move=> hr; have := le_lt_trans hr r_lt0; rewrite normr_lt0.
 rewrite ler_distl=> /andP[lx ux].
 rewrite ler_paddl //.
 elim/poly_ind: p=> [|p c ihp].
@@ -82,18 +82,18 @@ have [->|p_neq0 /=] := altP eqP.
   rewrite big_ord_recl big_ord0 addr0 coefC /=.
   by rewrite ler_pmulr ?normr_gt0 // ler_addl ler_maxr !normr_ge0.
 rewrite big_ord_recl coefD coefMX coefC eqxx add0r.
-rewrite (ler_trans (ler_norm_add _ _)) // addrC ler_add //.
+rewrite (le_trans (ler_norm_add _ _)) // addrC ler_add //.
   by rewrite expr0 mulr1.
 rewrite normrM.
-move: ihp=> /(ler_wpmul2r (normr_ge0 x)) /ler_trans-> //.
+move: ihp=> /(ler_wpmul2r (normr_ge0 x)) /le_trans-> //.
 rewrite mulr_suml ler_sum // => i _.
 rewrite coefD coefC coefMX /= addr0 exprSr mulrA.
 rewrite ler_wpmul2l //.
   by rewrite ?mulr_ge0 ?exprn_ge0 ?ler_maxr ?addr_ge0 ?normr_ge0 // ltrW.
 rewrite (ger0_norm r_ge0) ler_norml opprD.
-rewrite (ler_trans _ lx) ?(ler_trans ux) // ler_add2r.
-  by rewrite ler_normr lerr.
-by rewrite ler_oppl ler_normr lerr orbT.
+rewrite (le_trans _ lx) ?(le_trans ux) // ler_add2r.
+  by rewrite ler_normr lexx.
+by rewrite ler_oppl ler_normr lexx orbT.
 Qed.
 
 Lemma poly_bound_gt0 p a r : 0 < poly_bound p a r.
@@ -103,7 +103,7 @@ by rewrite mulr_ge0 ?exprn_ge0 ?addr_ge0 ?ler_maxr ?normr_ge0 // ltrW.
 Qed.
 
 Lemma poly_bound_ge0 p a r : 0 <= poly_bound p a r.
-Proof. by rewrite ltrW // poly_bound_gt0. Qed.
+Proof. by rewrite ltW // poly_bound_gt0. Qed.
 
 Definition poly_accr_bound (p : {poly F}) (a r : F) : F
   := (maxr 1 (2%:R * r)) ^+ (size p).-1
@@ -114,33 +114,33 @@ Lemma poly_accr_bound1P p a r x y :
   `|p.[y] - p.[x]| <= `|y - x| * poly_accr_bound p a r.
 Proof.
 have [|r_lt0] := lerP 0 r; last first.
-  by move=> hr; have := ler_lt_trans hr r_lt0; rewrite normr_lt0.
+  by move=> hr; have := le_lt_trans hr r_lt0; rewrite normr_lt0.
 rewrite le0r=> /orP[/eqP->|r_gt0 hx hy].
   by rewrite !normr_le0 !subr_eq0=> /eqP-> /eqP->; rewrite !subrr normr0 mul0r.
 rewrite mulrA mulrDr mulr1 ler_paddl ?mulr_ge0 ?normr_ge0 //=.
-  by rewrite exprn_ge0 ?ler_maxr ?mulr_ge0 ?ger0E ?ltrW.
+  by rewrite exprn_ge0 ?lexU ?mulr_ge0 ?ger0E ?ltW.
 rewrite -{1}(addNKr x y) [- _ + _]addrC /= -mulrA.
 rewrite nderiv_taylor; last exact: mulrC.
 have [->|p_neq0] := eqVneq p 0.
   rewrite size_poly0 big_ord0 horner0 subr0 normr0 mulr_ge0 ?normr_ge0 //.
-  by rewrite big_ord0 mulr0 lerr.
+  by rewrite big_ord0 mulr0 lexx.
 rewrite -[size _]prednK ?lt0n ?size_poly_eq0 //.
 rewrite big_ord_recl expr0 mulr1 nderivn0 addrC addKr !mulr_sumr.
-have := ler_trans (ler_norm_sum _ _ _); apply.
+have := le_trans (ler_norm_sum _ _ _); apply.
 rewrite ler_sum // => i _.
 rewrite exprSr mulrA !normrM mulrC ler_wpmul2l ?normr_ge0 //.
-suff /ler_wpmul2l /ler_trans :
+suff /ler_wpmul2l /le_trans :
   `|(y - x) ^+ i| <=  maxr 1 (2%:R * r) ^+ (size p).-1.
   apply; rewrite ?normr_ge0 // mulrC ler_wpmul2l ?poly_boundP //.
-  by rewrite ?exprn_ge0 // ler_maxr ler01 mulr_ge0 ?ler0n ?ltrW.
-case: maxrP=> hr.
+  by rewrite ?exprn_ge0 // lexU ler01 mulr_ge0 ?ler0n ?ltW.
+case: (leP _ 1)=> hr.
   rewrite expr1n normrX exprn_ile1 ?normr_ge0 //.
-  rewrite (ler_trans (ler_dist_add a _ _)) // addrC distrC.
-  by rewrite (ler_trans _ hr) // mulrDl ler_add ?mul1r.
-rewrite (@ler_trans _ ((2%:R * r) ^+ i)) //.
-  rewrite normrX @ler_expn2r -?topredE /= ?normr_ge0 ?mulr_ge0 ?ler0n //.
-    by rewrite ltrW.
-  rewrite (ler_trans (ler_dist_add a _ _)) // addrC distrC.
+  rewrite (le_trans (ler_dist_add a _ _)) // addrC distrC.
+  by rewrite (le_trans _ hr) // mulrDl ler_add ?mul1r.
+apply: le_trans (_ : (2%:R * r) ^+ i <= _).
+  rewrite normrX ler_expn2r -?topredE /= ?normr_ge0 ?mulr_ge0 ?ler0n //.
+    by rewrite ltW.
+  rewrite (le_trans (ler_dist_add a _ _)) // addrC distrC.
   by rewrite mulrDl ler_add ?mul1r.
 by rewrite ler_eexpn2l // ltnW.
 Qed.
@@ -150,11 +150,11 @@ Proof.
 rewrite /poly_accr_bound pmulr_rgt0 //.
   rewrite ltr_paddr ?ltr01 //.
   by rewrite sumr_ge0 // => i; rewrite poly_bound_ge0.
-by rewrite exprn_gt0 // ltr_maxr ltr01 pmulr_rgt0 ?ltr0n.
+by rewrite exprn_gt0 // ltxU ltr01 pmulr_rgt0 ?ltr0n.
 Qed.
 
 Lemma poly_accr_bound_ge0 p a r : 0 <= poly_accr_bound p a r.
-Proof. by rewrite ltrW // poly_accr_bound_gt0. Qed.
+Proof. by rewrite ltW // poly_accr_bound_gt0. Qed.
 
 (* Todo : move to polyorder => need char 0 *)
 Lemma gdcop_eq0 (p q : {poly F}) :
@@ -212,11 +212,11 @@ Proof.
 rewrite /poly_accr_bound pmulr_rgt0 //.
   rewrite ltr_paddr ?ltr01 //.
   by rewrite sumr_ge0 // => i; rewrite poly_bound_ge0.
-by rewrite exprn_gt0 // ltr_maxr ltr01 pmulr_rgt0 ?ltr0n.
+by rewrite exprn_gt0 // ltxU ltr01 pmulr_rgt0 ?ltr0n.
 Qed.
 
 Lemma poly_accr_bound2_ge0 p a r : 0 <= poly_accr_bound2 p a r.
-Proof. by rewrite ltrW // poly_accr_bound2_gt0. Qed.
+Proof. by rewrite ltW // poly_accr_bound2_gt0. Qed.
 
 Lemma poly_accr_bound2P p (a r x y : F) : (x != y)%B ->
   `|x - a| <= r ->  `|y - a| <= r ->
@@ -224,13 +224,13 @@ Lemma poly_accr_bound2P p (a r x y : F) : (x != y)%B ->
     <= `|y - x| * poly_accr_bound2 p a r.
 Proof.
 have [|r_lt0] := lerP 0 r; last first.
-  by move=> _ hr; have := ler_lt_trans hr r_lt0; rewrite normr_lt0.
+  by move=> _ hr; have := le_lt_trans hr r_lt0; rewrite normr_lt0.
 rewrite le0r=> /orP[/eqP->|r_gt0].
   rewrite !normr_le0 !subr_eq0.
   by move=> nxy /eqP xa /eqP xb; rewrite xa xb eqxx in nxy.
 move=> neq_xy hx hy.
 rewrite mulrA mulrDr mulr1 ler_paddl ?mulr_ge0 ?normr_ge0 //=.
-  by rewrite exprn_ge0 ?ler_maxr ?mulr_ge0 ?ger0E ?ltrW.
+  by rewrite exprn_ge0 ?lexU ?mulr_ge0 ?ger0E ?ltW.
 rewrite -{1}(addNKr x y) [- _ + _]addrC /= -mulrA.
 rewrite nderiv_taylor; last exact: mulrC.
 have [->|p_neq0] := eqVneq p 0.
@@ -244,21 +244,21 @@ rewrite addrAC subrr add0r mulrDl mulfK; last by rewrite subr_eq0 eq_sym.
 rewrite nderivn1 addrAC subrr add0r mulr_sumr normrM normfV.
 rewrite ler_pdivr_mulr ?normr_gt0; last by rewrite subr_eq0 eq_sym.
 rewrite mulrAC -expr2 mulrC mulr_suml.
-have := ler_trans (ler_norm_sum _ _ _); apply.
+have := le_trans (ler_norm_sum _ _ _); apply.
 rewrite ler_sum // => i _ /=; rewrite /bump /= !add1n.
 rewrite normrM normrX 3!exprSr expr1 !mulrA !ler_wpmul2r ?normr_ge0 //.
-suff /ler_wpmul2l /ler_trans :
+suff /ler_wpmul2l /le_trans :
   `|(y - x)| ^+ i <=  maxr 1 (2%:R * r) ^+ (size p^`()).-1.
   apply; rewrite ?normr_ge0 // mulrC ler_wpmul2l ?poly_boundP //.
-  by rewrite ?exprn_ge0 // ler_maxr ler01 mulr_ge0 ?ler0n ?ltrW.
-case: maxrP=> hr.
+  by rewrite ?exprn_ge0 // lexU ler01 mulr_ge0 ?ler0n ?ltW.
+case: (leP _ 1)=> hr.
   rewrite expr1n exprn_ile1 ?normr_ge0 //.
-  rewrite (ler_trans (ler_dist_add a _ _)) // addrC distrC.
-  by rewrite (ler_trans _ hr) // mulrDl ler_add ?mul1r.
-rewrite (@ler_trans _ ((2%:R * r) ^+ i)) //.
-  rewrite @ler_expn2r -?topredE /= ?normr_ge0 ?mulr_ge0 ?ler0n //.
-    by rewrite ltrW.
-  rewrite (ler_trans (ler_dist_add a _ _)) // addrC distrC.
+  rewrite (le_trans (ler_dist_add a _ _)) // addrC distrC.
+  by rewrite (le_trans _ hr) // mulrDl ler_add ?mul1r.
+apply: le_trans (_ : (2%:R * r) ^+ i <= _).
+  rewrite ler_expn2r -?topredE /= ?normr_ge0 ?mulr_ge0 ?ler0n //.
+    by rewrite ltW.
+  rewrite (le_trans (ler_dist_add a _ _)) // addrC distrC.
   by rewrite mulrDl ler_add ?mul1r.
 by rewrite ler_eexpn2l // ltnW.
 Qed.
@@ -287,26 +287,26 @@ Lemma accr_pos_incr p a r : accr_pos p a r ->
   forall x y, `|x - a| <= r -> `|y - a| <= r -> (p.[x] <= p.[y]) = (x <= y).
 Proof.
 move=> [[k k_gt0 hk] _] x y hx hy.
-have [->|neq_xy] := eqVneq x y; first by rewrite !lerr.
+have [->|neq_xy] := eqVneq x y; first by rewrite !lexx.
 have hkxy := hk _ _ neq_xy hx hy.
-have := ltr_trans k_gt0 hkxy.
+have := lt_trans k_gt0 hkxy.
 have [lpxpy|lpypx|->] := ltrgtP p.[x] p.[y].
-+ by rewrite nmulr_rgt0 ?subr_lt0 // ?invr_lt0 subr_lt0=> /ltrW->.
-+ by rewrite pmulr_rgt0 ?subr_gt0 // ?invr_gt0 subr_gt0 lerNgt=> ->.
-by rewrite subrr mul0r ltrr.
++ by rewrite nmulr_rgt0 ?subr_lt0 // ?invr_lt0 subr_lt0=> /ltW->.
++ by rewrite pmulr_rgt0 ?subr_gt0 // ?invr_gt0 subr_gt0 leNgt=> ->.
+by rewrite subrr mul0r ltxx.
 Qed.
 
 Lemma accr_neg_decr p a r : accr_neg p a r ->
   forall x y, `|x - a| <= r -> `|y - a| <= r -> (p.[x] <= p.[y]) = (y <= x).
 Proof.
 move=> [] [k]; rewrite -oppr_lt0=> Nk_lt0 hk _ x y hx hy.
-have [->|neq_xy] := eqVneq x y; first by rewrite !lerr.
+have [->|neq_xy] := eqVneq x y; first by rewrite !lexx.
 have hkxy := hk _ _ neq_xy hx hy.
-have := ltr_trans hkxy  Nk_lt0.
+have := lt_trans hkxy  Nk_lt0.
 have [lpxpy|lpypx|->] := ltrgtP p.[x] p.[y].
-+ by rewrite nmulr_rlt0 ?subr_lt0 // ?invr_gt0 subr_gt0=> /ltrW->.
-+ by rewrite pmulr_rlt0 ?subr_gt0 // ?invr_lt0 subr_lt0 lerNgt=> ->.
-by rewrite subrr mul0r ltrr.
++ by rewrite nmulr_rlt0 ?subr_lt0 // ?invr_gt0 subr_gt0=> /ltW->.
++ by rewrite pmulr_rlt0 ?subr_gt0 // ?invr_lt0 subr_lt0 leNgt=> ->.
+by rewrite subrr mul0r ltxx.
 Qed.
 
 Lemma accr_negN p a r : accr_pos p a r -> accr_neg (- p) a r.
@@ -335,8 +335,8 @@ Proof.
 case=> [] [[k k_gt0 hk] _]; exists k^-1; rewrite ?invr_gt0=> // x y hx hy;
 have [->|neq_xy] := eqVneq x y; do ?[by rewrite !subrr normr0 mulr0];
 move: (hk _ _ neq_xy hx hy); rewrite 1?ltr_oppr ler_pdivl_mull //;
-rewrite -ler_pdivl_mulr ?normr_gt0 ?subr_eq0 // => /ltrW /ler_trans-> //;
-by rewrite -normfV -normrM ler_normr lerr ?orbT.
+rewrite -ler_pdivl_mulr ?normr_gt0 ?subr_eq0 // => /ltW /le_trans-> //;
+by rewrite -normfV -normrM ler_normr lexx ?orbT.
 Qed.
 
 Definition merge_intervals (ar1 ar2 : F * F) :=
@@ -353,22 +353,23 @@ Lemma split_interval (a1 a2 r1 r2 x : F) :
 Proof.
 move=> r1_gt0 r2_gt0 le_ar.
 rewrite /merge_intervals /=.
-set l := minr _ _; set u := maxr _ _.
+set l : F := minr _ _; set u : F := maxr _ _.
 rewrite ler_pdivl_mulr ?gtr0E // -{2}[2%:R]ger0_norm ?ger0E //.
 rewrite -normrM mulrBl mulfVK ?pnatr_eq0 // ler_distl.
 rewrite opprB addrCA addrK (addrC (l + u)) addrA addrNK.
 rewrite -!mulr2n !mulr_natr !ler_muln2r !orFb.
-rewrite ler_minl ler_maxr !ler_distl.
+rewrite leIx lexU !ler_distl /=.
+set le := <=%R; rewrite {}/le.
 have [] := lerP=> /= a1N; have [] := lerP=> //= a1P;
 have [] := lerP=> //= a2P; rewrite ?(andbF, andbT) //; symmetry.
-  rewrite ltrW // (ler_lt_trans _ a1P) //.
+  rewrite ltW // (le_lt_trans _ a1P) //.
   rewrite (monoLR (addrK _) (ler_add2r _)) -addrA.
   rewrite (monoRL (addNKr _) (ler_add2l _)) addrC.
-  by rewrite (ler_trans _ le_ar) // ler_normr opprB lerr orbT.
-rewrite ltrW // (ltr_le_trans a1N) //.
+  by rewrite (le_trans _ le_ar) // ler_normr opprB lexx orbT.
+rewrite ltW // (lt_le_trans a1N) //.
 rewrite (monoLR (addrK _) (ler_add2r _)) -addrA.
 rewrite (monoRL (addNKr _) (ler_add2l _)) addrC ?[r2 + _]addrC.
-by rewrite (ler_trans _ le_ar) // ler_normr lerr.
+by rewrite (le_trans _ le_ar) // ler_normr lexx.
 Qed.
 
 Lemma merge_mono p a1 a2 r1 r2 :
@@ -387,39 +388,39 @@ move=> [] accr2_p; last first.
   set m := (r2 * a1 + r1 * a2) / (r1 + r2).
   have pm_gt0 := h1 m.
   case: accr2_p=> [_] /(_ m) pm_lt0.
-  suff: 0 < 0 :> F by rewrite ltrr.
+  suff: 0 < 0 :> F by rewrite ltxx.
   have r_gt0 : 0 < r1 + r2 by rewrite ?addr_gt0.
-  apply: (ltr_trans (pm_gt0 _) (pm_lt0 _)).
+  apply: (lt_trans (pm_gt0 _) (pm_lt0 _)).
     rewrite -(@ler_pmul2l _ (r1 + r2)) //.
-    rewrite -{1}[r1 + r2]ger0_norm ?(ltrW r_gt0) //.
-    rewrite -normrM mulrBr /m mulrC mulrVK ?unitfE ?gtr_eqF //.
+    rewrite -{1}[r1 + r2]ger0_norm ?(ltW r_gt0) //.
+    rewrite -normrM mulrBr /m mulrC mulrVK ?unitfE ?gt_eqF //.
     rewrite mulrDl opprD addrA addrC addrA addKr.
-    rewrite distrC -mulrBr normrM ger0_norm ?(ltrW r1_gt0) //.
-    by rewrite mulrC ler_wpmul2r // ltrW.
+    rewrite distrC -mulrBr normrM ger0_norm ?(ltW r1_gt0) //.
+    by rewrite mulrC ler_wpmul2r // ltW.
   rewrite -(@ler_pmul2l _ (r1 + r2)) //.
-  rewrite -{1}[r1 + r2]ger0_norm ?(ltrW r_gt0) //.
-  rewrite -normrM mulrBr /m mulrC mulrVK ?unitfE ?gtr_eqF //.
+  rewrite -{1}[r1 + r2]ger0_norm ?(ltW r_gt0) //.
+  rewrite -normrM mulrBr /m mulrC mulrVK ?unitfE ?gt_eqF //.
   rewrite mulrDl opprD addrA addrK.
-  rewrite -mulrBr normrM ger0_norm ?(ltrW r2_gt0) //.
-  by rewrite mulrC ler_wpmul2r // ltrW.
+  rewrite -mulrBr normrM ger0_norm ?(ltW r2_gt0) //.
+  by rewrite mulrC ler_wpmul2r // ltW.
 case: accr2_p=> [[k2 k2_gt0 hk2]] h2.
 left; split; last by move=> x; rewrite split_interval // => /orP [/h1|/h2].
-exists (minr k1 k2); first by rewrite ltr_minr k1_gt0.
+exists (minr k1 k2); first by rewrite ltxI k1_gt0.
 move=> x y neq_xy; rewrite !split_interval //.
 wlog lt_xy: x y neq_xy / y < x.
   move=> hwlog; have [] := ltrP y x; first exact: hwlog.
-  rewrite ler_eqVlt (negPf neq_xy) /= => /hwlog hwlog' hx hy.
+  rewrite le_eqVlt (negPf neq_xy) /= => /hwlog hwlog' hx hy.
   rewrite -mulrNN -!invrN !opprB.
   by apply: hwlog'; rewrite // eq_sym.
 move=> {h1} {h2} {sm1}.
 wlog le_xr1 : a1 a2 r1 r2 k1 k2
   r1_gt0 r2_gt0 k1_gt0 k2_gt0 har hk1 hk2  / `|x - a1| <= r1.
   move=> hwlog h; move: (h)=> /orP [/hwlog|]; first exact.
-  move=> /(hwlog a2 a1 r2 r1 k2 k1) hwlog' ley; rewrite minrC.
+  move=> /(hwlog a2 a1 r2 r1 k2 k1) hwlog' ley; rewrite meetC.
   by apply: hwlog'; rewrite 1?orbC // distrC [r2 + _]addrC.
 move=> _.
 have [le_yr1|gt_yr1] := (lerP _ r1)=> /= [_|le_yr2].
-  by rewrite ltr_minl hk1.
+  by rewrite ltIx hk1.
 rewrite ltr_pdivl_mulr ?subr_gt0 //.
 pose z := a1 - r1.
 have hz1 : `|z - a1| <= r1 by rewrite addrC addKr normrN gtr0_norm.
@@ -427,28 +428,28 @@ have gt_yr1' : y + r1 < a1.
   rewrite addrC; move: gt_yr1.
   rewrite (monoLR (addrNK _) (ltr_add2r _)).
  rewrite /z ltr_normr opprB=> /orP[|-> //].
-  rewrite (monoRL (addrK a1) (ltr_add2r _))=> /ltr_trans /(_ lt_xy).
-  by rewrite ltrNge addrC; move: le_xr1; rewrite ler_distl=> /andP [_ ->].
+  rewrite (monoRL (addrK a1) (ltr_add2r _))=> /lt_trans /(_ lt_xy).
+  by rewrite ltNge addrC; move: le_xr1; rewrite ler_distl=> /andP [_ ->].
 have lt_yz : y < z by rewrite (monoRL (addrK _) (ltr_add2r _)).
 have hz2 : `|z - a2| <= r2.
   move: (har); rewrite ler_norml=> /andP [la ua].
   rewrite addrAC ler_distl ua andbT.
   rewrite -[a1](addrNK y) -[_ - _ + _ - _]addrA.
   rewrite ler_add //.
-    by rewrite (monoRL (addrK _) (ler_add2r _)) addrC ltrW.
+    by rewrite (monoRL (addrK _) (ler_add2r _)) addrC ltW.
   by move: le_yr2; rewrite ler_norml=> /andP[].
 have [<-|neq_zx] := eqVneq z x.
-  by rewrite -ltr_pdivl_mulr ?subr_gt0 // ltr_minl hk2 ?orbT // gtr_eqF.
+  by rewrite -ltr_pdivl_mulr ?subr_gt0 // ltIx hk2 ?orbT // gt_eqF.
 have lt_zx : z < x.
-  rewrite ltr_neqAle neq_zx /=.
+  rewrite lt_neqAle neq_zx /=.
   move: le_xr1; rewrite distrC ler_norml=> /andP[_].
   by rewrite !(monoLR (addrK _) (ler_add2r _)) addrC.
 rewrite -{1}[x](addrNK z) -{1}[p.[x]](addrNK p.[z]).
 rewrite !addrA -![_ - _ + _ - _]addrA mulrDr ltr_add //.
   rewrite -ltr_pdivl_mulr ?subr_gt0 //.
-  by rewrite ltr_minl hk1 ?gtr_eqF.
+  by rewrite ltIx hk1 ?gt_eqF.
 rewrite -ltr_pdivl_mulr ?subr_gt0 //.
-by rewrite ltr_minl hk2 ?orbT ?gtr_eqF.
+by rewrite ltIx hk2 ?orbT ?gt_eqF.
 Qed.
 
 End monotony.
@@ -542,16 +543,16 @@ Proof. by move=> e_gt0 n_gt0; rewrite pmulr_rgt0 ?gtr0E. Qed.
 
 Lemma split_norm_add (x y e : F) :
   `|x| < e / 2%:R -> `|y| < e / 2%:R -> `|x + y| < e.
-Proof. by move=> hx hy; rewrite (ler_lt_trans (ler_norm_add _ _)) // splitD. Qed.
+Proof. by move=> hx hy; rewrite (le_lt_trans (ler_norm_add _ _)) // splitD. Qed.
 
 Lemma split_norm_sub (x y e : F) :
   `|x| < e / 2%:R -> `|y| < e / 2%:R -> `|x - y| < e.
-Proof. by move=> hx hy; rewrite (ler_lt_trans (ler_norm_sub _ _)) // splitD. Qed.
+Proof. by move=> hx hy; rewrite (le_lt_trans (ler_norm_sub _ _)) // splitD. Qed.
 
 Lemma split_dist_add (z x y e : F) :
   `|x - z| < e / 2%:R -> `|z - y| < e / 2%:R -> `|x - y| < e.
 Proof.
-by move=> *; rewrite (ler_lt_trans (ler_dist_add z _ _)) ?splitD // 1?distrC.
+by move=> *; rewrite (le_lt_trans (ler_dist_add z _ _)) ?splitD // 1?distrC.
 Qed.
 
 Definition creal_axiom (x : nat -> F) :=  {asympt e : i j / `|x i - x j| < e}.
@@ -583,7 +584,7 @@ Lemma ltr_distl_creal (e : F) (i : nat) (x : creal) (j : nat) (a b : F) :
   `| x i - a | <= b - e -> `| x j - a | < b.
 Proof.
 move=> e_gt0 hi hj hb.
-rewrite (ler_lt_trans (ler_dist_add (x i) _ _)) ?ltr_le_add //.
+rewrite (le_lt_trans (ler_dist_add (x i) _ _)) ?ltr_le_add //.
 by rewrite -[b](addrNK e) addrC ler_lt_add ?cauchymodP.
 Qed.
 
@@ -591,7 +592,7 @@ Lemma ltr_distr_creal (e : F) (i : nat) (x : creal) (j : nat) (a b : F) :
   0 < e -> (cauchymod x e <= i)%N -> (cauchymod x e <= j)%N ->
   a + e <= `| x i - b | -> a < `| x j - b |.
 Proof.
-move=> e_gt0 hi hj hb; apply: contraLR hb; rewrite -ltrNge -lerNgt.
+move=> e_gt0 hi hj hb; apply: contraLR hb; rewrite -ltNge -leNgt.
 by move=> ha; rewrite (@ltr_distl_creal e j) // addrK.
 Qed.
 
@@ -613,9 +614,9 @@ Lemma lboundP (x y : creal) (neq_xy : x != y) i :
   (cauchymod y (lbound neq_xy) <= i)%N -> lbound neq_xy <= `|x i - y i|.
 Proof.
 rewrite /lbound; case: (sigW _)=> /= d /andP[d_gt0 hd] hi hj.
-apply: contraLR hd; rewrite -!ltrNge=> hd.
-rewrite (@ltr_distl_creal d i) // distrC ltrW // (@ltr_distl_creal d i) //.
-by rewrite distrC ltrW // !mulrDr mulr1 !addrA !addrK.
+apply: contraLR hd; rewrite -!ltNge=> hd.
+rewrite (@ltr_distl_creal d i) // distrC ltW // (@ltr_distl_creal d i) //.
+by rewrite distrC ltW // !mulrDr mulr1 !addrA !addrK.
 Qed.
 
 Notation lbound_of p := (@lboundP _ _ p _ _ _).
@@ -623,7 +624,7 @@ Notation lbound_of p := (@lboundP _ _ p _ _ _).
 Lemma lbound_gt0 (x y : creal) (neq_xy : x != y) : lbound neq_xy > 0.
 Proof. by rewrite /lbound; case: (sigW _)=> /= d /andP[]. Qed.
 
-Definition lbound_ge0 x y neq_xy := (ltrW (@lbound_gt0 x y neq_xy)).
+Definition lbound_ge0 x y neq_xy := (ltW (@lbound_gt0 x y neq_xy)).
 
 Lemma cst_crealP (x : F) : creal_axiom (fun _ => x).
 Proof. by exists (fun _ => 0%N)=> *; rewrite subrr normr0. Qed.
@@ -644,8 +645,8 @@ Lemma neq_crealP e i j (e_gt0 : 0 < e) (x y : creal) :
   e <= `|x i - y j| ->  x != y.
 Proof.
 move=> hi hj he; exists (e / 5%:R); rewrite pmulr_rgt0 ?gtr0E //=.
-rewrite distrC ltrW // (@ltr_distr_creal (e / 5%:R) j) ?pmulr_rgt0 ?gtr0E //.
-rewrite distrC ltrW // (@ltr_distr_creal (e / 5%:R) i) ?pmulr_rgt0 ?gtr0E //.
+rewrite distrC ltW // (@ltr_distr_creal (e / 5%:R) j) ?pmulr_rgt0 ?gtr0E //.
+rewrite distrC ltW // (@ltr_distr_creal (e / 5%:R) i) ?pmulr_rgt0 ?gtr0E //.
 by rewrite mulr_natr -!mulrSr -mulrnAr -mulr_natr mulVf ?pnatr_eq0 ?mulr1.
 Qed.
 
@@ -655,7 +656,7 @@ Proof.
 case=> m hm neq_xy; pose d := lbound neq_xy.
 pose_big_enough i.
   have := (hm d i); rewrite lbound_gt0; big_enough => /(_ isT isT).
-  by apply/negP; rewrite -lerNgt lboundP.
+  by apply/negP; rewrite -leNgt lboundP.
 by close.
 Qed.
 
@@ -668,7 +669,7 @@ Lemma asympt_eq (x y : creal) (eq_xy : x == y) :
   {asympt e : i / `|x i - y i| < e}.
 Proof.
 exists_big_modulus m F.
-   move=> e i e0 hi; rewrite ltrNge; apply/negP=> he; apply: eq_xy.
+   move=> e i e0 hi; rewrite ltNge; apply/negP=> he; apply: eq_xy.
    by apply: (@neq_crealP e i i).
 by close.
 Qed.
@@ -718,7 +719,7 @@ Lemma creal_neq_always (x y : creal) i (neq_xy : x != y) :
   (cauchymod y (lbound neq_xy) <= i)%N -> (x i != y i)%B.
 Proof.
 move=> hx hy; rewrite -subr_eq0 -normr_gt0.
-by rewrite (ltr_le_trans _ (lbound_of neq_xy)) ?lbound_gt0.
+by rewrite (lt_le_trans _ (lbound_of neq_xy)) ?lbound_gt0.
 Qed.
 
 Definition creal_neq0_always (x : creal) := @creal_neq_always x 0.
@@ -738,7 +739,7 @@ Lemma ltr_creal (e : F) (i : nat) (x : creal) (j : nat) (a : F) :
   x i <= a - e -> x j < a.
 Proof.
 move=> e_gt0 hi hj ha; have := cauchymodP e_gt0 hj hi.
-rewrite ltr_distl=> /andP[_ /ltr_le_trans-> //].
+rewrite ltr_distl=> /andP[_ /lt_le_trans-> //].
 by rewrite -(ler_add2r (- e)) addrK.
 Qed.
 
@@ -747,7 +748,7 @@ Lemma gtr_creal (e : F) (i : nat) (x : creal) (j : nat) (a : F) :
   a + e <= x i-> a < x j.
 Proof.
 move=> e_gt0 hi hj ha; have := cauchymodP e_gt0 hj hi.
-rewrite ltr_distl=> /andP[/(ler_lt_trans _)-> //].
+rewrite ltr_distl=> /andP[/(le_lt_trans _)-> //].
 by rewrite -(ler_add2r e) addrNK.
 Qed.
 
@@ -756,15 +757,15 @@ Definition diff (x y : creal) (lt_xy : (x < y)%CR) : F := projT1 (sigW lt_xy).
 Lemma diff_gt0 (x y : creal) (lt_xy : (x < y)%CR) : diff lt_xy > 0.
 Proof. by rewrite /diff; case: (sigW _)=> /= d /andP[]. Qed.
 
-Definition diff_ge0 x y lt_xy := (ltrW (@diff_gt0 x y lt_xy)).
+Definition diff_ge0 x y lt_xy := (ltW (@diff_gt0 x y lt_xy)).
 
 Lemma diffP (x y : creal) (lt_xy : (x < y)%CR) i :
   (cauchymod x (diff lt_xy) <= i)%N ->
   (cauchymod y (diff lt_xy) <= i)%N -> x i + diff lt_xy <= y i.
 Proof.
 rewrite /diff; case: (sigW _)=> /= e /andP[e_gt0 he] hi hj.
-rewrite ltrW // (@gtr_creal e (cauchymod y e)) // (ler_trans _ he) //.
-rewrite !mulrDr mulr1 !addrA !ler_add2r ltrW //.
+rewrite ltW // (@gtr_creal e (cauchymod y e)) // (le_trans _ he) //.
+rewrite !mulrDr mulr1 !addrA !ler_add2r ltW //.
 by rewrite (@ltr_creal e (cauchymod x e)) // addrK.
 Qed.
 
@@ -782,9 +783,9 @@ Lemma lt_crealP e i j (e_gt0 : 0 < e) (x y : creal) :
   x i + e <= y j ->  (x < y)%CR.
 Proof.
 move=> hi hj he; exists (e / 5%:R); rewrite pmulr_rgt0 ?gtr0E //=.
-rewrite ltrW // (@gtr_creal (e / 5%:R) j) ?pmulr_rgt0 ?gtr0E //.
-rewrite (ler_trans _ he) // -addrA (monoLR (addrNK _) (ler_add2r _)).
-rewrite ltrW // (@ltr_creal (e / 5%:R) i) ?pmulr_rgt0 ?gtr0E //.
+rewrite ltW // (@gtr_creal (e / 5%:R) j) ?pmulr_rgt0 ?gtr0E //.
+rewrite (le_trans _ he) // -addrA (monoLR (addrNK _) (ler_add2r _)).
+rewrite ltW // (@ltr_creal (e / 5%:R) i) ?pmulr_rgt0 ?gtr0E //.
 rewrite -!addrA ler_addl !addrA -mulrA -{1}[e]mulr1 -!(mulrBr, mulrDr).
 rewrite pmulr_rge0 // {1}[1](splitf 5) /= !mul1r !mulrDr mulr1.
 by rewrite !opprD !addrA !addrK addrN.
@@ -794,8 +795,8 @@ Lemma le_crealP i (x y : creal) :
   (forall j, (i <= j)%N -> x j <= y j) -> (x <= y)%CR.
 Proof.
 move=> hi lt_yx; pose_big_enough j.
-  have := hi j; big_enough => /(_ isT); apply/negP; rewrite -ltrNge.
-  by rewrite (ltr_le_trans _ (diff_of lt_yx)) ?ltr_spaddr ?diff_gt0.
+  have := hi j; big_enough => /(_ isT); apply/negP; rewrite -ltNge.
+  by rewrite (lt_le_trans _ (diff_of lt_yx)) ?ltr_spaddr ?diff_gt0.
 by close.
 Qed.
 
@@ -807,7 +808,7 @@ Lemma lt_neq_creal (x y : creal) : (x < y)%CR -> x != y.
 Proof.
 move=> ltxy; pose_big_enough i.
   apply: (@neq_crealP (diff ltxy) i i) => //; first by rewrite diff_gt0.
-  by rewrite distrC lerNgt ltr_distl negb_and -!lerNgt diffP ?orbT.
+  by rewrite distrC leNgt ltr_distl negb_and -!leNgt diffP ?orbT.
 by close.
 Qed.
 
@@ -815,7 +816,7 @@ Lemma creal_lt_always (x y : creal) i (lt_xy : (x < y)%CR) :
   (cauchymod x (diff lt_xy) <= i)%N ->
   (cauchymod y (diff lt_xy) <= i)%N -> x i < y i.
 Proof.
-by move=> hx hy; rewrite (ltr_le_trans _ (diff_of lt_xy)) ?ltr_addl ?diff_gt0.
+by move=> hx hy; rewrite (lt_le_trans _ (diff_of lt_xy)) ?ltr_addl ?diff_gt0.
 Qed.
 
 Definition creal_gt0_always := @creal_lt_always 0.
@@ -827,7 +828,7 @@ Lemma asympt_le (x y : creal) (le_xy : (x <= y)%CR) :
   {asympt e : i / x i < y i + e}.
 Proof.
 exists_big_modulus m F.
-  move=> e i e0 hm; rewrite ltrNge; apply/negP=> he; apply: le_xy.
+  move=> e i e0 hm; rewrite ltNge; apply/negP=> he; apply: le_xy.
   by apply: (@lt_crealP e i i).
 by close.
 Qed.
@@ -873,15 +874,15 @@ Proof.
 pose_big_enough i; first set b := 1 + `|x i|.
   exists (foldl maxr b [seq `|x n| | n <- iota 0 i]) => [|n].
     have : 0 < b by rewrite ltr_spaddl.
-    by elim: iota b => //= a l IHl b b_gt0; rewrite IHl ?ltr_maxr ?b_gt0.
+    by elim: iota b => //= a l IHl b b_gt0; rewrite IHl ?ltxU ?b_gt0.
   have [|le_in] := (ltnP n i).
     elim: i b => [|i IHi] b //.
-    rewrite ltnS -addn1 iota_add add0n map_cat foldl_cat /= ler_maxr leq_eqVlt.
-    by case/orP=> [/eqP->|/IHi->] //; rewrite lerr orbT.
+    rewrite ltnS -addn1 iota_add add0n map_cat foldl_cat /= lexU leq_eqVlt.
+    by case/orP=> [/eqP->|/IHi->] //; rewrite lexx orbT.
   set xn := `|x n|; suff : xn <= b.
-    by elim: iota xn b => //= a l IHl xn b Hxb; rewrite IHl ?ler_maxr ?Hxb.
-  rewrite -ler_subl_addr (ler_trans (ler_norm _)) //.
-  by rewrite (ler_trans (ler_dist_dist _ _)) ?ltrW ?cauchymodP.
+    by elim: iota xn b => //= a l IHl xn b Hxb; rewrite IHl ?lexU ?Hxb.
+  rewrite -ler_subl_addr (le_trans (ler_norm _)) //.
+  by rewrite (le_trans (ler_dist_dist _ _)) ?ltW ?cauchymodP.
 by close.
 Qed.
 
@@ -894,7 +895,7 @@ Proof. by rewrite /ubound; case: ubound_subproof. Qed.
 Lemma ubound_gt0 x : 0 < ubound x.
 Proof. by rewrite /ubound; case: ubound_subproof. Qed.
 
-Definition ubound_ge0 x := (ltrW (ubound_gt0 x)).
+Definition ubound_ge0 x := (ltW (ubound_gt0 x)).
 
 Lemma mul_crealP (x y : creal) :  creal_axiom (fun i => x i * y i).
 Proof.
@@ -902,10 +903,10 @@ exists_big_modulus m F.
   move=> e i j e_gt0 hi hj.
   rewrite -[_ * _]subr0 -(subrr (x j * y i)) opprD opprK addrA.
   rewrite -mulrBl -addrA -mulrBr split_norm_add // !normrM.
-    have /ler_wpmul2l /ler_lt_trans-> // := uboundP y i.
+    have /ler_wpmul2l /le_lt_trans-> // := uboundP y i.
     rewrite -ltr_pdivl_mulr ?ubound_gt0 ?cauchymodP //.
     by rewrite !pmulr_rgt0 ?invr_gt0 ?ubound_gt0 ?ltr0n.
-  rewrite mulrC; have /ler_wpmul2l /ler_lt_trans-> // := uboundP x j.
+  rewrite mulrC; have /ler_wpmul2l /le_lt_trans-> // := uboundP x j.
   rewrite -ltr_pdivl_mulr ?ubound_gt0 ?cauchymodP //.
   by rewrite !pmulr_rgt0 ?gtr0E ?ubound_gt0.
 by close.
@@ -921,15 +922,15 @@ exists_big_modulus m F.
  (* exists (fun e => [CC x # e * d ^+ 2; ! x_neq0]). *)
   move=> e i j e_gt0 hi hj.
   have /andP[xi_neq0 xj_neq0] : (x i != 0) && (x j != 0).
-    by rewrite -!normr_gt0 !(ltr_le_trans _ (lbound0_of x_neq0)) ?lbound_gt0.
+    by rewrite -!normr_gt0 !(lt_le_trans _ (lbound0_of x_neq0)) ?lbound_gt0.
   rewrite -(@ltr_pmul2r _ `|x i * x j|); last by rewrite normr_gt0 mulf_neq0.
   rewrite -normrM !mulrBl mulrA mulVf // mulrCA mulVf // mul1r mulr1.
-  apply: (@ltr_le_trans _ (e * d ^+ 2)).
+  apply: lt_le_trans (_ : e * d ^+ 2 <= _).
     by apply: cauchymodP; rewrite // !pmulr_rgt0 ?lbound_gt0.
-  rewrite ler_wpmul2l ?(ltrW e_gt0) // normrM.
-  have /(_ j) hx := lbound0_of x_neq0; rewrite /=.
-  have -> // := (ler_trans (@ler_wpmul2l _ d _ _ _ (hx _ _))).
-    by rewrite ltrW // lbound_gt0.
+  rewrite ler_wpmul2l ?(ltW e_gt0) // normrM.
+  have /(_ j) hx /= := lbound0_of x_neq0.
+  have -> // := (le_trans (ler_wpmul2l _ (hx _ _))).
+    by rewrite ltW // lbound_gt0.
   by rewrite ler_wpmul2r ?normr_ge0 // lbound0P.
 by close.
 Qed.
@@ -940,7 +941,7 @@ Notation "x / y_neq0" := (x * (y_neq0 ^-1))%CR : creal_scope.
 Lemma norm_crealP (x : creal) : creal_axiom (fun i => `|x i|).
 Proof.
 exists (cauchymod x).
-by move=> *; rewrite (ler_lt_trans (ler_dist_dist _ _)) ?cauchymodP.
+by move=> *; rewrite (le_lt_trans (ler_dist_dist _ _)) ?cauchymodP.
 Qed.
 Definition norm_creal x := CReal (norm_crealP x).
 Local Notation "`| x |" := (norm_creal x) : creal_scope.
@@ -949,8 +950,8 @@ Lemma horner_crealP (p : {poly F}) (x : creal) :
   creal_axiom (fun i => p.[x i]).
 Proof.
 exists_big_modulus m F=> [e i j e_gt0 hi hj|].
-  rewrite (ler_lt_trans (@poly_accr_bound1P _ p (x (cauchymod x 1)) 1 _ _ _ _));
-    do ?[by rewrite ?e_gt0 | by rewrite ltrW // cauchymodP].
+  rewrite (le_lt_trans (@poly_accr_bound1P _ p (x (cauchymod x 1)) 1 _ _ _ _));
+    do ?[by rewrite ?e_gt0 | by rewrite ltW // cauchymodP].
   rewrite -ltr_pdivl_mulr ?poly_accr_bound_gt0 ?cauchymodP //.
   by rewrite pmulr_rgt0 ?invr_gt0 ?poly_accr_bound_gt0.
 by close.
@@ -966,21 +967,21 @@ pose_big_enough i.
   pose k := 2%:R + poly_accr_bound p (y i) d.
   have /andP[d_gt0 k_gt0] : (0 < d) && (0 < k).
     rewrite ?(ltr_spaddl, poly_accr_bound_ge0);
-    by rewrite ?ltr0n ?ltrW ?ltr01 ?lbound_gt0.
+    by rewrite ?ltr0n ?ltW ?ltr01 ?lbound_gt0.
   pose_big_enough j.
     apply: (@neq_crealP (d / k) j j) => //.
       by rewrite ?(pmulr_lgt0, invr_gt0, ltr0n).
     rewrite ler_pdivr_mulr //.
     have /(_ j) // := (lbound_of neq_px_py).
     big_enough=> /(_ isT isT).
-    apply: contraLR; rewrite -!ltrNge=> hxy.
-    rewrite (ler_lt_trans (@poly_accr_bound1P _ _ (y i) d _ _ _ _)) //.
-    + by rewrite ltrW // cauchymodP.
-    + rewrite ltrW // (@split_dist_add (y j)) //; last first.
+    apply: contraLR; rewrite -!ltNge=> hxy.
+    rewrite (le_lt_trans (@poly_accr_bound1P _ _ (y i) d _ _ _ _)) //.
+    + by rewrite ltW // cauchymodP.
+    + rewrite ltW // (@split_dist_add (y j)) //; last first.
         by rewrite cauchymodP ?divrn_gt0.
-      rewrite ltr_pdivl_mulr ?ltr0n // (ler_lt_trans _ hxy) //.
+      rewrite ltr_pdivl_mulr ?ltr0n // (le_lt_trans _ hxy) //.
       by rewrite ler_wpmul2l ?normr_ge0 // ler_paddr // poly_accr_bound_ge0.
-    rewrite (ler_lt_trans _ hxy) // ler_wpmul2l ?normr_ge0 //.
+    rewrite (le_lt_trans _ hxy) // ler_wpmul2l ?normr_ge0 //.
     by rewrite ler_paddl // ?ler0n.
   by close.
 by close.
@@ -1025,10 +1026,10 @@ move=> x y eq_xy z t eq_zt; apply: eq_crealP.
 exists_big_modulus m F.
   move=> e i e_gt0 hi.
   rewrite (@split_dist_add (y i * z i)) // -(mulrBl, mulrBr) normrM.
-    have /ler_wpmul2l /ler_lt_trans-> // := uboundP z i.
+    have /ler_wpmul2l /le_lt_trans-> // := uboundP z i.
     rewrite -ltr_pdivl_mulr ?ubound_gt0 ?eq_modP //.
     by rewrite !pmulr_rgt0 ?invr_gt0 ?ubound_gt0 ?ltr0n.
-  rewrite mulrC; have /ler_wpmul2l /ler_lt_trans-> // := uboundP y i.
+  rewrite mulrC; have /ler_wpmul2l /le_lt_trans-> // := uboundP y i.
   rewrite -ltr_pdivl_mulr ?ubound_gt0 ?eq_modP //.
   by rewrite !pmulr_rgt0 ?invr_gt0 ?ubound_gt0 ?ltr0n.
 by close.
@@ -1042,9 +1043,9 @@ move=> eq_xy; apply: eq_crealP; exists_big_modulus m F.
   move=> e i e_gt0 hi /=.
   rewrite -(@ltr_pmul2r _ (lbound x_neq0 * lbound y_neq0));
     do ?by rewrite ?pmulr_rgt0 ?lbound_gt0.
-  rewrite (@ler_lt_trans _ (`|(x i)^-1 - (y i)^-1| * (`|x i| * `|y i|))) //.
+  apply: le_lt_trans (_ : `|(x i)^-1 - (y i)^-1| * (`|x i| * `|y i|) < _).
     rewrite ler_wpmul2l ?normr_ge0 //.
-    rewrite (@ler_trans _ (`|x i| * lbound y_neq0)) //.
+    apply: le_trans (_ : `|x i| * lbound y_neq0 <= _).
       by rewrite ler_wpmul2r ?lbound_ge0 ?lbound0P.
     by rewrite ler_wpmul2l ?normr_ge0 ?lbound0P.
   rewrite -!normrM mulrBl mulKf ?creal_neq0_always //.
@@ -1072,12 +1073,12 @@ have le_zt : (z <= t)%CR by apply: eq_le_creal.
 have le_xy : (y <= x)%CR by apply: eq_le_creal; apply: eq_creal_sym.
 pose_big_enough i.
   apply: (@lt_crealP e' i i)=> //.
-  rewrite ltrW // -(ltr_add2r e').
-  rewrite (ler_lt_trans _ (@le_modP _ _ le_zt _ _ _ _)) //.
-  rewrite -addrA (monoLR (@addrNK _ _) (@ler_add2r _ _)) ltrW //.
-  rewrite (ltr_le_trans (@le_modP _ _ le_xy e' _ _ _)) //.
-  rewrite -(monoLR (@addrNK _ _) (@ler_add2r _ _)) ltrW //.
-  rewrite (ltr_le_trans _ (diff_of lxz)) //.
+  rewrite ltW // -(ltr_add2r e').
+  rewrite (le_lt_trans _ (@le_modP _ _ le_zt _ _ _ _)) //.
+  rewrite -addrA (monoLR (@addrNK _ _) (@ler_add2r _ _)) ltW //.
+  rewrite (lt_le_trans (@le_modP _ _ le_xy e' _ _ _)) //.
+  rewrite -(monoLR (@addrNK _ _) (@ler_add2r _ _)) ltW //.
+  rewrite (lt_le_trans _ (diff_of lxz)) //.
   rewrite -addrA ler_lt_add // /e' -!mulrDr gtr_pmulr ?diff_gt0 //.
   by rewrite [X in _ < X](splitf 4) /=  mul1r !ltr_addr ?gtr0E.
 by close.
@@ -1094,7 +1095,7 @@ Add Morphism norm_creal
 Proof.
 move=> x y hxy; apply: eq_crealP; exists_big_modulus m F.
   move=> e i e_gt0 hi.
-  by rewrite (ler_lt_trans (ler_dist_dist _ _)) ?eq_modP.
+  by rewrite (le_lt_trans (ler_dist_dist _ _)) ?eq_modP.
 by close.
 Qed.
 Global Existing Instance norm_creal_morph_Proper.
@@ -1103,7 +1104,7 @@ Lemma neq_creal_ltVgt (x y : creal) : x != y -> {(x < y)%CR} + {(y < x)%CR}.
 Proof.
 move=> neq_xy; pose_big_enough i.
   have := (@lboundP _ _ neq_xy i); big_enough => /(_ isT isT).
-  have [le_xy|/ltrW le_yx'] := lerP (x i) (y i).
+  have [le_xy|/ltW le_yx'] := lerP (x i) (y i).
     rewrite -(ler_add2r (x i)) ?addrNK addrC.
     move=> /lt_crealP; rewrite ?lbound_gt0; big_enough.
     by do 3!move/(_ isT); left.
@@ -1130,7 +1131,7 @@ Proof.
 move=> lt_xy lt_yz; pose_big_enough i.
   apply: (@lt_crealP (diff lt_xy + diff lt_yz) i i) => //.
     by rewrite addr_gt0 ?diff_gt0.
-  rewrite (ler_trans _ (diff_of lt_yz)) //.
+  rewrite (le_trans _ (diff_of lt_yz)) //.
   by rewrite addrA ler_add2r (diff_of lt_xy).
 by close.
 Qed.
@@ -1207,10 +1208,7 @@ apply: (iffP idP)=> lt_xy; pose_big_enough i.
 Qed.
 
 Lemma le_creal_cst x y : reflect (cst_creal x <= cst_creal y)%CR (x <= y).
-Proof.
-apply: (iffP idP)=> [le_xy /lt_creal_cst|eq_xy]; first by rewrite ltrNge le_xy.
-by rewrite lerNgt; apply/negP=> /lt_creal_cst.
-Qed.
+Proof. by rewrite leNgt; apply: (iffP negP)=> ? /lt_creal_cst. Qed.
 
 
 Lemma mul_creal_neq0 x y : x != 0 -> y != 0 -> x * y != 0.
@@ -1220,7 +1218,7 @@ pose d := lbound x_neq0 * lbound y_neq0.
 have d_gt0 : 0 < d by rewrite pmulr_rgt0 lbound_gt0.
 pose_big_enough i.
   apply: (@neq_crealP d i i)=> //; rewrite subr0 normrM.
-  rewrite (@ler_trans _ (`|x i| * lbound y_neq0)) //.
+  apply: le_trans (_ : `|x i| * lbound y_neq0 <= _).
     by rewrite ler_wpmul2r ?lbound_ge0 // lbound0P.
   by rewrite ler_wpmul2l ?normr_ge0 // lbound0P.
 by close.
@@ -1232,7 +1230,7 @@ move=> xy_neq0; pose_big_enough i.
   apply: (@neq_crealP ((ubound x)^-1 * lbound xy_neq0) i i) => //.
     by rewrite pmulr_rgt0 ?invr_gt0 ?lbound_gt0 ?ubound_gt0.
   rewrite subr0 ler_pdivr_mull ?ubound_gt0 //.
-  have /(_ i)-> // := (ler_trans (lbound0_of xy_neq0)).
+  have /(_ i)-> // := (le_trans (lbound0_of xy_neq0)).
   by rewrite normrM ler_wpmul2r ?normr_ge0 ?uboundP.
 by close.
 Qed.
@@ -1251,13 +1249,13 @@ move=> /Bezout_eq1_coprimepP /sig_eqW [[u v] /= hpq]; pose_big_enough i.
     apply: (@mul_neq0_creal v.[x]).
     apply: (@neq_crealP 2%:R^-1 i i); rewrite ?gtr0E //.
     rewrite /= subr0 -hornerM -(ler_add2l `|upxi|).
-    rewrite (ler_trans _ (ler_norm_add _ _)) // hpqi normr1.
+    rewrite (le_trans _ (ler_norm_add _ _)) // hpqi normr1.
     rewrite (monoLR (addrNK _) (ler_add2r _)).
     by rewrite {1}[1](splitf 2) /= mul1r addrK.
   move=> qx0; apply: pqx0; apply: mul_creal_neq0=> //.
   apply: (@mul_neq0_creal u.[x]).
   apply: (@neq_crealP 2%:R^-1 i i); rewrite ?gtr0E //.
-  by rewrite /= subr0 -hornerM ltrW.
+  by rewrite /= subr0 -hornerM ltW.
 by close.
 Qed.
 
@@ -1271,7 +1269,7 @@ Lemma root_poly_expn_creal p k x : (0 < k)%N
 Proof.
 move=> k_gt0 pkx_eq0; apply: eq_crealP; exists_big_modulus m F.
   move=> e i e_gt0 hi; rewrite /= subr0.
-  rewrite -(@ltr_pexpn2r _ k) -?topredE /= ?normr_ge0 ?ltrW //.
+  rewrite -(@ltr_pexpn2r _ k) -?topredE /= ?normr_ge0 ?ltW //.
   by rewrite -normrX -horner_exp (@eq0_modP _ pkx_eq0) ?exprn_gt0 //.
 by close.
 Qed.
@@ -1329,11 +1327,11 @@ pose_big_enough i.
   apply: (@neq_crealP ((ubound v.[x])%CR^-1 / 2%:R) i i) => //.
     by rewrite pmulr_rgt0 ?gtr0E // ubound_gt0.
   rewrite /= subr0 ler_pdivr_mull ?ubound_gt0 //.
-  rewrite (@ler_trans _  `|(v * q).[x i]|) //; last first.
+  apply: le_trans (_ : `|(v * q).[x i]| <= _); last first.
     by rewrite hornerM normrM ler_wpmul2r ?normr_ge0 ?(uboundP v.[x]).
-  rewrite -(ler_add2l `|upxi|) (ler_trans _ (ler_norm_add _ _)) // hpqi normr1.
+  rewrite -(ler_add2l `|upxi|) (le_trans _ (ler_norm_add _ _)) // hpqi normr1.
   rewrite (monoLR (addrNK _) (ler_add2r _)).
-  rewrite {1}[1](splitf 2) /= mul1r addrK ltrW // /upxi hornerM.
+  rewrite {1}[1](splitf 2) /= mul1r addrK ltW // /upxi hornerM.
   by rewrite (@eq0_modP _ upx_eq0) ?gtr0E.
 by close.
 Qed.
@@ -1361,28 +1359,28 @@ wlog : p px_neq0 / (0 < p^`().[x])%CR.
 move=> px_gt0.
 pose b1 := poly_accr_bound p^`() 0 (1 + ubound x).
 pose b2 := poly_accr_bound2 p 0 (1 + ubound x).
-pose r := minr 1 (minr
+pose r : F := minr 1 (minr
   (diff px_gt0 / 4%:R / b1)
   (diff px_gt0 / 4%:R / b2 / 2%:R)).
 exists r.
-  rewrite !ltr_minr ?ltr01 ?pmulr_rgt0 ?gtr0E ?diff_gt0;
+  rewrite !ltxI ?ltr01 ?pmulr_rgt0 ?gtr0E ?diff_gt0;
   by rewrite ?poly_accr_bound2_gt0 ?poly_accr_bound_gt0.
 pose_big_enough i.
   exists i => //; left; split; last first.
     move=> y hy; have := (@poly_accr_bound1P _ p^`() 0 (1 + ubound x) (x i) y).
     rewrite ?subr0 ler_paddl ?ler01 ?uboundP //.
-    rewrite (@ler_trans _ (r + `|x i|)) ?subr0; last 2 first.
+    rewrite (le_trans (_ : _ <= r + `|x i|)) ?subr0; last 2 first.
     + rewrite (monoRL (addrNK _) (ler_add2r _)).
-      by rewrite (ler_trans (ler_sub_dist _ _)).
-    + by rewrite ler_add ?ler_minl ?lerr ?uboundP.
+      by rewrite (le_trans (ler_sub_dist _ _)).
+    + by rewrite ler_add ?leIx ?lexx ?uboundP.
     move=> /(_ isT isT).
     rewrite ler_distl=> /andP[le_py ge_py].
-    rewrite (ltr_le_trans _ le_py) // subr_gt0 -/b1.
-    rewrite (ltr_le_trans _ (diff0_of px_gt0)) //.
-    rewrite (@ler_lt_trans _ (r * b1)) //.
+    rewrite (lt_le_trans _ le_py) // subr_gt0 -/b1.
+    rewrite (lt_le_trans _ (diff0_of px_gt0)) //.
+    apply: le_lt_trans (_ : r * b1 < _).
       by rewrite ler_wpmul2r ?poly_accr_bound_ge0.
     rewrite -ltr_pdivl_mulr ?poly_accr_bound_gt0 //.
-    rewrite !ltr_minl ltr_pmul2r ?invr_gt0 ?poly_accr_bound_gt0 //.
+    rewrite !ltIx ltr_pmul2r ?invr_gt0 ?poly_accr_bound_gt0 //.
     by rewrite gtr_pmulr ?diff_gt0 // invf_lt1 ?gtr0E ?ltr1n ?orbT.
   exists (diff px_gt0 / 4%:R).
    by rewrite pmulr_rgt0 ?gtr0E ?diff_gt0.
@@ -1390,30 +1388,30 @@ pose_big_enough i.
   have := (@poly_accr_bound1P _ p^`() 0 (1 + ubound x) (x i) z).
   have := @poly_accr_bound2P _ p 0 (1 + ubound x) z y; rewrite eq_sym !subr0.
   rewrite neq_yz ?ler01 ?ubound_ge0=> // /(_ isT).
-  rewrite (@ler_trans _ (r + `|x i|)); last 2 first.
+  rewrite (le_trans (_ : _ <= r + `|x i|)); last 2 first.
   + rewrite (monoRL (addrNK _) (ler_add2r _)).
-    by rewrite (ler_trans (ler_sub_dist _ _)).
-  + rewrite ler_add ?ler_minl ?lerr ?uboundP //.
-  rewrite (@ler_trans _ (r + `|x i|)); last 2 first.
+    by rewrite (le_trans (ler_sub_dist _ _)).
+  + by rewrite ler_add ?leIx ?lexx ?uboundP.
+  rewrite (le_trans (_ : _ <= r + `|x i|)); last 2 first.
   + rewrite (monoRL (addrNK _) (ler_add2r _)).
-    by rewrite (ler_trans (ler_sub_dist _ _)).
-  + rewrite ler_add ?ler_minl ?lerr ?uboundP //.
+    by rewrite (le_trans (ler_sub_dist _ _)).
+  + by rewrite ler_add ?leIx ?lexx ?uboundP.
   rewrite ler_paddl ?uboundP ?ler01 //.
   move=> /(_ isT isT); rewrite ler_distl=> /andP [haccr _].
   move=> /(_ isT isT); rewrite ler_distl=> /andP [hp' _].
-  rewrite (ltr_le_trans _ haccr) // (monoRL (addrK _) (ltr_add2r _)).
-  rewrite (ltr_le_trans _ hp') // (monoRL (addrK _) (ltr_add2r _)).
-  rewrite (ltr_le_trans _ (diff0_of px_gt0)) //.
+  rewrite (lt_le_trans _ haccr) // (monoRL (addrK _) (ltr_add2r _)).
+  rewrite (lt_le_trans _ hp') // (monoRL (addrK _) (ltr_add2r _)).
+  rewrite (lt_le_trans _ (diff0_of px_gt0)) //.
   rewrite {2}[diff _](splitf 4) /= -!addrA ltr_add2l ltr_spaddl //.
     by rewrite pmulr_rgt0 ?gtr0E ?diff_gt0.
   rewrite -/b1 -/b2 ler_add //.
-    rewrite -ler_pdivl_mulr ?poly_accr_bound2_gt0 //.
-    rewrite (@ler_trans _ (r * 2%:R)) //.
-      rewrite (ler_trans (ler_dist_add (x i) _ _)) //.
-        by rewrite mulrDr mulr1 ler_add // distrC.
-      by rewrite -ler_pdivl_mulr ?ltr0n // !ler_minl lerr !orbT.
-    rewrite -ler_pdivl_mulr ?poly_accr_bound_gt0 //.
-    by rewrite (@ler_trans _ r) // !ler_minl lerr !orbT.
+  + rewrite -ler_pdivl_mulr ?poly_accr_bound2_gt0 //.
+    rewrite (le_trans (ler_dist_add (x i) _ _)) //.
+    apply: le_trans (_ : r * 2%:R <= _).
+      by rewrite mulrDr mulr1 ler_add // distrC.
+    by rewrite -ler_pdivl_mulr ?ltr0n // !leIx lexx !orbT.
+  + rewrite -ler_pdivl_mulr ?poly_accr_bound_gt0 //.
+    by rewrite (le_trans hz) // !leIx lexx !orbT.
 by close.
 Qed.
 
@@ -1474,7 +1472,7 @@ Lemma bound_poly_boundP (z : creal) i (q : {poly {poly F}}) (a r : F) j :
   poly_bound q.[(z i)%:P]^`N(j.+1) a r <= bound_poly_bound z q a r j.
 Proof.
 rewrite /poly_bound.
-pose f q (k : nat) :=  `|q^`N(j.+1)`_k| * (`|a| + `|r|) ^+ k.
+pose f (q : {poly F}) (k : nat) :=  `|q^`N(j.+1)`_k| * (`|a| + `|r|) ^+ k.
 rewrite ler_add //=.
 rewrite (big_ord_widen (sizeY q) (f q.[(z i)%:P])); last first.
   rewrite size_nderivn leq_subLR (leq_trans (max_size_evalC _ _)) //.
@@ -1486,22 +1484,22 @@ rewrite !horner_coef.
 rewrite !(@big_morph _ _ (fun p => p^`N(j.+1)) 0 +%R);
   do ?[by rewrite raddf0|by move=> x y /=; rewrite raddfD].
 rewrite !coef_sum.
-rewrite (ler_trans (ler_norm_sum _ _ _)) //.
+rewrite (le_trans (ler_norm_sum _ _ _)) //.
 rewrite ger0_norm; last first.
   rewrite sumr_ge0=> //= l _.
   rewrite coef_nderivn mulrn_wge0 ?natr_ge0 //.
   rewrite -polyC_exp coefMC coef_norm_poly2 mulr_ge0 ?normr_ge0 //.
-  by rewrite exprn_ge0 ?ltrW ?ubound_gt0.
+  by rewrite exprn_ge0 ?ltW ?ubound_gt0.
 rewrite size_norm_poly2 ler_sum //= => l _.
 rewrite !{1}coef_nderivn normrMn ler_pmuln2r ?bin_gt0 ?leq_addr //.
 rewrite -!polyC_exp !coefMC coef_norm_poly2 normrM ler_wpmul2l ?normr_ge0 //.
 rewrite normrX; case: (val l)=> // {l} l.
-by rewrite ler_pexpn2r -?topredE //= ?uboundP ?ltrW ?ubound_gt0.
+by rewrite ler_pexpn2r -?topredE //= ?uboundP ?ltW ?ubound_gt0.
 Qed.
 
 Lemma bound_poly_bound_ge0 z q a r i : 0 <= bound_poly_bound z q a r i.
 Proof.
-by rewrite (ler_trans _ (bound_poly_boundP _ 0%N _ _ _ _)) ?poly_bound_ge0.
+by rewrite (le_trans _ (bound_poly_boundP _ 0%N _ _ _ _)) ?poly_bound_ge0.
 Qed.
 
 Definition bound_poly_accr_bound (z : creal) (q : {poly {poly F}}) (a r : F) :=
@@ -1513,14 +1511,14 @@ Lemma bound_poly_accr_boundP (z : creal) i (q : {poly {poly F}}) (a r : F) :
 Proof.
 rewrite /poly_accr_bound /bound_poly_accr_bound /=.
 set ui := _ ^+ _; set u := _ ^+ _; set vi := 1 + _.
-rewrite (@ler_trans _ (u * vi)) //.
+apply: le_trans (_ : u * vi <= _).
   rewrite ler_wpmul2r //.
     by rewrite addr_ge0 ?ler01 // sumr_ge0 //= => j _; rewrite poly_bound_ge0.
-  rewrite /ui /u; case: maxrP; first by rewrite !expr1n.
+  rewrite /ui /u; case: (ltP 1%R); last by rewrite !expr1n.
   move=> r2_gt1; rewrite ler_eexpn2l //.
   rewrite -subn1 leq_subLR add1n (leq_trans _ (leqSpred _)) //.
   by rewrite max_size_evalC.
-rewrite ler_wpmul2l ?exprn_ge0 ?ler_maxr ?ler01 // ler_add //.
+rewrite ler_wpmul2l ?exprn_ge0 ?lexU ?ler01 // ler_add //.
 pose f j :=  poly_bound q.[(z i)%:P]^`N(j.+1) a r.
 rewrite (big_ord_widen (sizeY q).-1 f); last first.
   rewrite -subn1 leq_subLR add1n (leq_trans _ (leqSpred _)) //.
@@ -1532,7 +1530,7 @@ Qed.
 Lemma bound_poly_accr_bound_gt0 (z : creal) (q : {poly {poly F}}) (a r : F) :
   0 < bound_poly_accr_bound z q a r.
 Proof.
-rewrite (ltr_le_trans _ (bound_poly_accr_boundP _ 0%N _ _ _)) //.
+rewrite (lt_le_trans _ (bound_poly_accr_boundP _ 0%N _ _ _)) //.
 by rewrite poly_accr_bound_gt0.
 Qed.
 
@@ -1542,18 +1540,18 @@ Proof.
 set a := x (cauchymod x 1).
 exists_big_modulus m F.
   move=> e i j e_gt0 hi hj; rewrite (@split_dist_add p.[x i, y j]) //.
-    rewrite (ler_lt_trans (@poly_accr_bound1P _ _ 0 (ubound y) _ _ _ _)) //;
+    rewrite (le_lt_trans (@poly_accr_bound1P _ _ 0 (ubound y) _ _ _ _)) //;
       do ?by rewrite ?subr0 ?uboundP.
-    rewrite (@ler_lt_trans _ (`|y i - y j|
-                            * bound_poly_accr_bound x p 0 (ubound y))) //.
+    apply: le_lt_trans
+             (_ : `|y i - y j| * bound_poly_accr_bound x p 0 (ubound y) < _).
       by rewrite ler_wpmul2l ?normr_ge0 // bound_poly_accr_boundP.
     rewrite -ltr_pdivl_mulr ?bound_poly_accr_bound_gt0 //.
     by rewrite cauchymodP // !pmulr_rgt0 ?gtr0E ?bound_poly_accr_bound_gt0.
   rewrite -[p]swapXYK  ![(swapXY (swapXY _)).[_, _]]horner2_swapXY.
-  rewrite (ler_lt_trans (@poly_accr_bound1P _ _ 0 (ubound x) _ _ _ _)) //;
+  rewrite (le_lt_trans (@poly_accr_bound1P _ _ 0 (ubound x) _ _ _ _)) //;
     do ?by rewrite ?subr0 ?uboundP.
-  rewrite (@ler_lt_trans _ (`|x i - x j|
-                   * bound_poly_accr_bound y (swapXY p) 0 (ubound x))) //.
+  apply: le_lt_trans
+      (_ : `|x i - x j| * bound_poly_accr_bound y (swapXY p) 0 (ubound x) < _).
     by rewrite ler_wpmul2l ?normr_ge0 // bound_poly_accr_boundP.
   rewrite -ltr_pdivl_mulr ?bound_poly_accr_bound_gt0 //.
   by rewrite cauchymodP // !pmulr_rgt0 ?gtr0E ?bound_poly_accr_bound_gt0.
@@ -1580,11 +1578,11 @@ have [||[u v] /= [hu hv] hpq] := @sub_annihilant_in_ideal _ p q.
 apply: eq_crealP; exists_big_modulus m F.
   move=> e i e_gt0 hi /=; rewrite subr0.
   rewrite (hpq (y i)) addrCA subrr addr0 split_norm_add // normrM.
-    rewrite (@ler_lt_trans _ ((ubound u.[y, x - y]) * `|p.[x i]|)) //.
+    apply: le_lt_trans (_ : (ubound u.[y, x - y]) * `|p.[x i]| < _).
       by rewrite ler_wpmul2r ?normr_ge0 // (uboundP u.[y, x - y] i).
     rewrite -ltr_pdivl_mull ?ubound_gt0 //.
     by rewrite (@eq0_modP _ px_eq0) // !pmulr_rgt0 ?gtr0E ?ubound_gt0.
-  rewrite (@ler_lt_trans _ ((ubound v.[y, x - y]) * `|q.[y i]|)) //.
+  apply: le_lt_trans (_ : (ubound v.[y, x - y]) * `|q.[y i]| < _).
     by rewrite ler_wpmul2r ?normr_ge0 // (uboundP v.[y, x - y] i).
   rewrite -ltr_pdivl_mull ?ubound_gt0 //.
   by rewrite (@eq0_modP _ qy_eq0) // !pmulr_rgt0 ?gtr0E ?ubound_gt0.
@@ -1602,13 +1600,13 @@ have [||[u v] /= [hu hv] hpq] := @div_annihilant_in_ideal _ p q.
 apply: eq_crealP; exists_big_modulus m F.
   move=> e i e_gt0 hi /=; rewrite subr0.
   rewrite (hpq (y i)) mulrCA divff ?mulr1; last first.
-    by rewrite -normr_gt0 (ltr_le_trans _ (lbound0_of y_neq0)) ?lbound_gt0.
+    by rewrite -normr_gt0 (lt_le_trans _ (lbound0_of y_neq0)) ?lbound_gt0.
   rewrite split_norm_add // normrM.
-    rewrite (@ler_lt_trans _ ((ubound u.[y, x / y_neq0]) * `|p.[x i]|)) //.
+    apply: le_lt_trans (_ : (ubound u.[y, x / y_neq0]) * `|p.[x i]| < _).
       by rewrite ler_wpmul2r ?normr_ge0 // (uboundP u.[y, x / y_neq0] i).
     rewrite -ltr_pdivl_mull ?ubound_gt0 //.
     by rewrite (@eq0_modP _ px_eq0) // !pmulr_rgt0 ?gtr0E ?ubound_gt0.
-  rewrite (@ler_lt_trans _ ((ubound v.[y, x / y_neq0]) * `|q.[y i]|)) //.
+  apply: le_lt_trans (_ : (ubound v.[y, x / y_neq0]) * `|q.[y i]| < _).
     by rewrite ler_wpmul2r ?normr_ge0 // (uboundP v.[y, x / y_neq0] i).
   rewrite -ltr_pdivl_mull ?ubound_gt0 //.
   by rewrite (@eq0_modP _ qy_eq0) // !pmulr_rgt0 ?gtr0E ?ubound_gt0.

--- a/theories/complex.v
+++ b/theories/complex.v
@@ -4,9 +4,9 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp
 Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp
-Require Import bigop ssralg ssrint div ssrnum rat poly closed_field polyrcf.
+Require Import bigop order ssralg ssrint div ssrnum rat poly closed_field.
 From mathcomp
-Require Import matrix mxalgebra tuple mxpoly zmodp binomial realalg.
+Require Import polyrcf matrix mxalgebra tuple mxpoly zmodp binomial realalg.
 
 (**********************************************************************)
 (*   This files defines the extension R[i] of a real field R,         *)
@@ -16,7 +16,7 @@ Require Import matrix mxalgebra tuple mxpoly zmodp binomial realalg.
 (* (cf comments below, thanks to Pierre Lairez for finding the paper) *)
 (**********************************************************************)
 
-Import GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -257,8 +257,8 @@ Qed.
 
 Lemma eq0_normc x : normc x = 0 -> x = 0.
 Proof.
-case: x => a b /= /eqP; rewrite sqrtr_eq0 ler_eqVlt => /orP [|]; last first.
-  by rewrite ltrNge addr_ge0 ?sqr_ge0.
+case: x => a b /= /eqP; rewrite sqrtr_eq0 le_eqVlt => /orP [|]; last first.
+  by rewrite ltNge addr_ge0 ?sqr_ge0.
 by rewrite paddr_eq0 ?sqr_ge0 ?expf_eq0 //= => /andP[/eqP -> /eqP ->].
 Qed.
 
@@ -267,7 +267,7 @@ Lemma eq0_normC x : normC x = 0 -> x = 0. Proof. by case=> /eq0_normc. Qed.
 Lemma ge0_lec_total x y : lec 0 x -> lec 0 y -> lec x y || lec y x.
 Proof.
 move: x y => [a b] [c d] /= /andP[/eqP -> a_ge0] /andP[/eqP -> c_ge0].
-by rewrite eqxx ler_total.
+by rewrite eqxx le_total.
 Qed.
 
 Lemma normcM x y : normc (x * y) = normc x * normc y.
@@ -296,7 +296,7 @@ Qed.
 Lemma ltc_def x y : ltc x y = (y != x) && lec x y.
 Proof.
 move: x y => [a b] [c d] /=; simpc; rewrite eq_complex /=.
-by have [] := altP eqP; rewrite ?(andbF, andbT) //= ltr_def.
+by have [] := altP eqP; rewrite ?(andbF, andbT) //= lt_def.
 Qed.
 
 Lemma lec_normD x y : lec (normC (x + y)) (normC x + normC y).
@@ -312,7 +312,7 @@ rewrite [u + _] addrC [X in _ - X]addrAC [b ^+ _ + _]addrC.
 rewrite [u]lock [v]lock !addrA; set x := (a ^+ 2 + _ + _ + _).
 rewrite -addrA addrC addKr -!lock addrC.
 have [huv|] := ger0P (u + v); last first.
-  by move=> /ltrW /ler_trans -> //; rewrite pmulrn_lge0 // mulr_ge0 ?sqrtr_ge0.
+  by move=> /ltW /le_trans -> //; rewrite pmulrn_lge0 // mulr_ge0 ?sqrtr_ge0.
 rewrite -(@ler_pexpn2r _ 2) -?topredE //=; last first.
   by rewrite ?(pmulrn_lge0, mulr_ge0, sqrtr_ge0) //.
 rewrite -mulr_natl !exprMn !sqr_sqrtr ?(ler_paddr, sqr_ge0) //.
@@ -325,7 +325,10 @@ Qed.
 
 Definition complex_numMixin := NumMixin lec_normD ltc0_add eq0_normC
      ge0_lec_total normCM lec_def ltc_def.
+Canonical complex_porderType := POrderType ring_display R[i] complex_numMixin.
 Canonical complex_numDomainType := NumDomainType R[i] complex_numMixin.
+Canonical complex_normedZmodType :=
+  NormedZmoduleType R[i] R[i] complex_numMixin.
 
 End ComplexField.
 End ComplexField.
@@ -338,7 +341,9 @@ Canonical ComplexField.complex_unitRingType.
 Canonical ComplexField.complex_comUnitRingType.
 Canonical ComplexField.complex_idomainType.
 Canonical ComplexField.complex_fieldType.
+Canonical ComplexField.complex_porderType.
 Canonical ComplexField.complex_numDomainType.
+Canonical ComplexField.complex_normedZmodType.
 Canonical complex_numFieldType (R : rcfType) := [numFieldType of complex R].
 Canonical ComplexField.real_complex_rmorphism.
 Canonical ComplexField.real_complex_additive.
@@ -583,11 +588,11 @@ have F2: `|a| <= sqrtr (a^+2 + b^+2).
   rewrite -sqrtr_sqr ler_wsqrtr //.
   by rewrite addrC -subr_ge0 addrK exprn_even_ge0.
 have F3: 0 <= (sqrtr (a ^+ 2 + b ^+ 2) - a) / 2%:R.
-  rewrite mulr_ge0 // subr_ge0 (ler_trans _ F2) //.
-  by rewrite -(maxrN a) ler_maxr lerr.
+  rewrite mulr_ge0 // subr_ge0 (le_trans _ F2) //.
+  by rewrite -(maxrN a) lexU lexx.
 have F4: 0 <= (sqrtr (a ^+ 2 + b ^+ 2) + a) / 2%:R.
-  rewrite mulr_ge0 // -{2}[a]opprK subr_ge0 (ler_trans _ F2) //.
-  by rewrite -(maxrN a) ler_maxr lerr orbT.
+  rewrite mulr_ge0 // -{2}[a]opprK subr_ge0 (le_trans _ F2) //.
+  by rewrite -(maxrN a) lexU lexx orbT.
 congr (_ +i* _); set u := if _ then _ else _.
   rewrite mulrCA !mulrA.
   have->: (u * u) = 1.
@@ -618,7 +623,7 @@ by rewrite -[_*+2]mulr_natr mulfK // pnatr_eq0.
 Qed.
 
 Lemma sqrtc0 : sqrtc 0 = 0.
-Proof. by rewrite sqrtc_sqrtr ?lerr // sqrtr0. Qed.
+Proof. by rewrite sqrtc_sqrtr ?lexx // sqrtr0. Qed.
 
 Lemma sqrtc1 : sqrtc 1 = 1.
 Proof. by rewrite sqrtc_sqrtr ?ler01 // sqrtr1. Qed.
@@ -1304,6 +1309,7 @@ End ComplexClosed.
 (* Canonical ComplexInternal.ComplexField.Re_additive. *)
 (* Canonical ComplexInternal.ComplexField.Im_additive. *)
 (* Canonical ComplexInternal.complex_numDomainType. *)
+(* Canonical ComplexInternal.complex_normedZmodType. *)
 (* Canonical ComplexInternal.complex_numFieldType. *)
 (* Canonical ComplexInternal.conjc_rmorphism. *)
 (* Canonical ComplexInternal.conjc_additive. *)
@@ -1348,7 +1354,10 @@ Canonical complexalg_idomainType := [idomainType of complexalg].
 Canonical complexalg_fieldType := [fieldType of complexalg].
 Canonical complexalg_decDieldType := [decFieldType of complexalg].
 Canonical complexalg_closedFieldType := [closedFieldType of complexalg].
+Canonical complexalg_porderType := [porderType of complexalg].
 Canonical complexalg_numDomainType := [numDomainType of complexalg].
+Canonical complexalg_normedZmodType :=
+  [normedZmodType complexalg of complexalg].
 Canonical complexalg_numFieldType := [numFieldType of complexalg].
 Canonical complexalg_numClosedFieldType := [numClosedFieldType of complexalg].
 

--- a/theories/complex.v
+++ b/theories/complex.v
@@ -328,7 +328,7 @@ Definition complex_numMixin := NumMixin lec_normD ltc0_add eq0_normC
 Canonical complex_porderType := POrderType ring_display R[i] complex_numMixin.
 Canonical complex_numDomainType := NumDomainType R[i] complex_numMixin.
 Canonical complex_normedZmodType :=
-  NormedZmoduleType R[i] R[i] complex_numMixin.
+  NormedZmodType R[i] R[i] complex_numMixin.
 
 End ComplexField.
 End ComplexField.

--- a/theories/ordered_qelim.v
+++ b/theories/ordered_qelim.v
@@ -4,7 +4,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp
 Require Import ssrfun ssrbool eqtype ssrnat seq div choice fintype.
 From mathcomp
-Require Import bigop ssralg finset fingroup zmodp.
+Require Import bigop order ssralg finset fingroup zmodp.
 From mathcomp
 Require Import poly ssrnum.
 
@@ -421,7 +421,7 @@ split=> t1.
   + by move=> t1 IHt1 n r /IHt1; case: to_rterm.
 Qed.
 
-Import Num.Theory.
+Import Order.TTheory Num.Theory.
 
 (* Correctness of the transformation. *)
 Lemma to_rformP e f : holds e (to_rform f) <-> holds e f.
@@ -676,8 +676,8 @@ Proof.
 move=> qev; have qevT f: qev f true = ~~ qev f false.
   rewrite {}/qev; elim: f => //=; do [by case | move=> f1 IH1 f2 IH2 | ].
   - by move=> t1 t2; rewrite !andbT !orbF.
-  - by move=> t1 t2; rewrite !andbT !orbF; rewrite !subr_gte0 -lerNgt.
-  - by move=> t1 t2; rewrite !andbT !orbF; rewrite !subr_gte0 -ltrNge.
+  - by move=> t1 t2; rewrite !andbT !orbF; rewrite !subr_gte0 -leNgt.
+  - by move=> t1 t2; rewrite !andbT !orbF; rewrite !subr_gte0 -ltNge.
   - by rewrite and_odnfP cat_dnfP negb_and -IH1 -IH2.
   - by rewrite and_odnfP cat_dnfP negb_or -IH1 -IH2.
   - by rewrite and_odnfP cat_dnfP /= negb_or IH1 -IH2 negbK.
@@ -810,7 +810,7 @@ suff {x1 x2 x3 x4} /= -> :
   holds e (odnf_to_oform s2) <-> eval e t == 0%:R /\ holds e (odnf_to_oform s1).
   suff /= -> :
     holds e (odnf_to_oform s3) <-> 0%:R < eval e t /\ holds e (odnf_to_oform s1).
-    rewrite ler_eqVlt eq_sym; split; first by case; case/orP=> -> ?; [left|right].
+    rewrite le_eqVlt eq_sym; split; first by case; case/orP=> -> ?; [left|right].
     by case; [case=> -> ? /= |case=> ->; rewrite orbT].
   rewrite /s1 /s3.
   elim: (leq_elim_aux eq_l lt_l le_l) => /= [| t1 l ih]; first by split=> // [[]].
@@ -896,8 +896,8 @@ suff {x1 x2 x3 x4} /= -> :
   suff /= -> :
     holds e (odnf_to_oform s3) <-> 0%:R < - eval e t /\ holds e (odnf_to_oform s1).
     rewrite oppr_gt0; split.
-      by case; move/eqP; rewrite neqr_lt; case/orP=> -> h1; [right | left].
-    by case; case=> h ?; split=> //; apply/eqP; rewrite neqr_lt h ?orbT.
+      by case; move/eqP; rewrite neq_lt; case/orP=> -> h1; [right | left].
+    by case; case=> h ?; split=> //; apply/eqP; rewrite neq_lt h ?orbT.
   rewrite /s1 /s3.
   elim: (neq_elim_aux lt_l neq_l) => /= [| t1 l ih] /=; first by split => //; case.
   set y1 := foldr _ _ _; set y2 := foldr _ _ _; set y3 := foldr _ _ _.

--- a/theories/ordered_qelim.v
+++ b/theories/ordered_qelim.v
@@ -76,7 +76,7 @@ Canonical term_eqMixin (T : eqType) := EqMixin (@term_eqP T).
 Canonical term_eqType (T : eqType) :=
    Eval hnf in EqType (term T) (@term_eqMixin T).
 
-Arguments term_eqP T [x y].
+Arguments term_eqP T {x y}.
 Prenex Implicits term_eq.
 
 
@@ -199,7 +199,7 @@ Canonical oclause_eqMixin (T : eqType) := EqMixin (@oclause_eqP T).
 Canonical oclause_eqType (T : eqType) :=
    Eval hnf in EqType (oclause T) (@oclause_eqMixin T).
 
-Arguments oclause_eqP T [x y].
+Arguments oclause_eqP T {x y}.
 Prenex Implicits oclause_eq.
 
 Section EvalTerm.

--- a/theories/polyrcf.v
+++ b/theories/polyrcf.v
@@ -4,7 +4,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp
 Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp
-Require Import bigop ssralg poly polydiv ssrnum zmodp.
+Require Import bigop order ssralg poly polydiv ssrnum zmodp.
 From mathcomp
 Require Import polyorder path interval ssrint.
 
@@ -35,8 +35,7 @@ Require Import polyorder path interval ssrint.
 (****************************************************************************)
 
 
-Import GRing.Theory Num.Theory Num.Def.
-Import Pdiv.Idomain.
+Import Order.TTheory GRing.Theory Num.Theory Num.Def Pdiv.Idomain.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -140,7 +139,7 @@ Lemma poly_pinfty_gt_lc p :
    lead_coef p > 0 ->
   exists n, forall x, x >= n -> p.[x] >= lead_coef p.
 Proof.
-elim/poly_ind: p => [| q c IHq]; first by rewrite lead_coef0 ltrr.
+elim/poly_ind: p => [| q c IHq]; first by rewrite lead_coef0 ltxx.
 have [->|q_neq0] := eqVneq q 0.
   by rewrite mul0r add0r lead_coefC => c_gt0; exists 0 => x _; rewrite hornerC.
 rewrite lead_coefDl ?size_mul ?polyX_eq0 // ?lead_coefMX; last first.
@@ -148,12 +147,12 @@ rewrite lead_coefDl ?size_mul ?polyX_eq0 // ?lead_coefMX; last first.
   by rewrite (leq_trans (leq_b1 _)) // size_poly_gt0.
 move=> lq_gt0; have [y Hy] := IHq lq_gt0.
 pose z := (1 + (lead_coef q) ^-1 * `|c|); exists (maxr y z) => x.
-have z_gt0 : 0 < z by rewrite ltr_spaddl ?ltr01 ?mulr_ge0 ?invr_ge0 // ltrW.
-rewrite !hornerE ler_maxl => /andP[/Hy Hq Hc].
-rewrite (@ler_trans _ (lead_coef q * z + c)) //; last first.
-  rewrite ler_add2r (@ler_trans _ (q.[x] * z)) // ?ler_pmul2r //.
-  by rewrite ler_pmul2l // (ltr_le_trans _ Hq).
-rewrite mulrDr mulr1 -addrA ler_addl mulVKf ?gtr_eqF //.
+have z_gt0 : 0 < z by rewrite ltr_spaddl ?ltr01 ?mulr_ge0 ?invr_ge0 // ltW.
+rewrite !hornerE leUx => /andP[/Hy Hq Hc].
+apply: le_trans (_ : lead_coef q * z + c <= _); last first.
+  rewrite ler_add2r (le_trans (_ : _ <= q.[x] * z)) // ?ler_pmul2r //.
+  by rewrite ler_pmul2l // (lt_le_trans _ Hq).
+rewrite mulrDr mulr1 -addrA ler_addl mulVKf ?gt_eqF //.
 by rewrite -[c]opprK subr_ge0 normrN ler_norm.
 Qed.
 
@@ -162,7 +161,7 @@ Lemma poly_lim_infty p m :
     lead_coef p > 0 -> (size p > 1)%N ->
   exists n, forall x, x >= n -> p.[x] >= m.
 Proof.
-elim/poly_ind: p m => [| q c _] m; first by rewrite lead_coef0 ltrr.
+elim/poly_ind: p m => [| q c _] m; first by rewrite lead_coef0 ltxx.
 have [-> _|q_neq0] := eqVneq q 0.
   by rewrite mul0r add0r size_polyC ltnNge leq_b1.
 rewrite lead_coefDl ?size_mul ?polyX_eq0 // ?lead_coefMX; last first.
@@ -171,14 +170,14 @@ rewrite lead_coefDl ?size_mul ?polyX_eq0 // ?lead_coefMX; last first.
 move=> lq_gt0; have [y Hy _] := poly_pinfty_gt_lc lq_gt0.
 pose z := (1 + (lead_coef q) ^-1 * (`|m| + `|c|)); exists (maxr y z) => x.
 have z_gt0 : 0 < z.
-  by rewrite ltr_spaddl ?ltr01 ?mulr_ge0 ?invr_ge0 ?addr_ge0 // ?ltrW.
-rewrite !hornerE ler_maxl => /andP[/Hy Hq Hc].
-rewrite (@ler_trans _ (lead_coef q * z + c)) //; last first.
-  rewrite ler_add2r (@ler_trans _ (q.[x] * z)) // ?ler_pmul2r //.
-  by rewrite ler_pmul2l // (ltr_le_trans _ Hq).
-rewrite mulrDr mulr1 mulVKf ?gtr_eqF // addrA -addrA ler_paddr //.
+  by rewrite ltr_spaddl ?ltr01 ?mulr_ge0 ?invr_ge0 ?addr_ge0 // ?ltW.
+rewrite !hornerE leUx => /andP[/Hy Hq Hc].
+apply: le_trans (_ : lead_coef q * z + c <= _); last first.
+  rewrite ler_add2r (le_trans (_ : _ <= q.[x] * z)) // ?ler_pmul2r //.
+  by rewrite ler_pmul2l // (lt_le_trans _ Hq).
+rewrite mulrDr mulr1 mulVKf ?gt_eqF // addrA -addrA ler_paddr //.
   by rewrite -[c]opprK subr_ge0 normrN ler_norm.
-by rewrite ler_paddl ?ler_norm // ?ltrW.
+by rewrite ler_paddl ?ler_norm // ?ltW.
 Qed.
 
 End SgpInfty.
@@ -197,43 +196,43 @@ case e: (size p) => [|n]; first by move: np0; rewrite -size_poly_eq0 e eqxx.
 have lcp : `|lead_coef p| > 0 by move: np0; rewrite -lead_coef_eq0 -normr_gt0.
 have lcn0 : `|lead_coef p| != 0 by rewrite normr_eq0 -normr_gt0.
 case: (lerP `|x| 1) => cx1.
-  rewrite (ler_trans cx1) // /cauchy_bound ler_pdivl_mull // mulr1.
+  rewrite (le_trans cx1) // /cauchy_bound ler_pdivl_mull // mulr1.
   by rewrite big_ord_recr /= /lead_coef e ler_addr sumr_ge0.
 case es:  n e => [|m] e.
   suff p0 : p = 0 by rewrite p0 eqxx in np0.
     by move: rpx; rewrite (@size1_polyC _ p) ?e ?lerr // hornerC; move->.
-move: rpx; rewrite horner_coef e -es big_ord_recr /=; move/eqP; rewrite eq_sym.
-rewrite -subr_eq sub0r; move/eqP => h1.
+move/eqP: rpx.
+rewrite horner_coef e -es big_ord_recr /= eq_sym -subr_eq sub0r => /eqP h1.
 have {h1} h1 : `|p`_n| * `|x| ^+ n <= \sum_(i < n) `|p`_i * x ^+ i|.
   rewrite -normrX -normrM -normrN h1.
-  by rewrite (ler_trans (ler_norm_sum _ _ _)) // lerr.
-have xp : `| x | > 0 by rewrite (ltr_trans _ cx1) ?ltr01.
+  by rewrite (le_trans (ler_norm_sum _ _ _)) // lerr.
+have xp : `| x | > 0 by rewrite (lt_trans _ cx1) ?ltr01.
 move: h1; rewrite {-1}es exprS mulrA -ler_pdivl_mulr ?exprn_gt0 //.
 rewrite big_distrl /= big_ord_recr /= normrM normrX -mulrA es mulfV; last first.
-  by rewrite expf_eq0 negb_and eq_sym (ltr_eqF xp) orbT.
+  by rewrite expf_eq0 negb_and eq_sym (lt_eqF xp) orbT.
 have pnp : 0 < `|p`_n|  by move: lcp; rewrite /lead_coef e es.
 rewrite mulr1 -es mulrC -ler_pdivl_mulr //.
 rewrite [_ / _]mulrC /cauchy_bound /lead_coef e -es /=.
-move=> h1; apply: (ler_trans h1) => //.
-rewrite ler_pmul2l ?invr_gt0 ?(ltrW pnp) // big_ord_recr /=.
+move=> h1; apply: (le_trans h1) => //.
+rewrite ler_pmul2l ?invr_gt0 ?(ltW pnp) // big_ord_recr /=.
 rewrite es [_ + `|p`_m.+1|]addrC ler_paddl // ?normr_ge0 //.
 rewrite big_ord_recr /= ler_add2r; apply: ler_sum => i.
 rewrite normrM normrX.
 rewrite -mulrA ler_pimulr ?normrE // ler_pdivr_mulr ?exprn_gt0 // mul1r.
-by rewrite ler_eexpn2l // 1?ltrW //; case: i=> i hi /=; rewrite ltnW.
+by rewrite ler_eexpn2l // 1?ltW //; case: i=> i hi /=; rewrite ltnW.
 (* this could be improved a little bit with int exponents *)
 Qed.
 
 Lemma le_cauchy_bound p : p != 0 -> {in `]-oo, (- cauchy_bound p)], noroot p}.
 Proof.
-move=> p_neq0 x; rewrite inE /= lerNgt; apply: contra => /rootP.
+move=> p_neq0 x; rewrite inE /= leNgt; apply: contra => /rootP.
 by move=> /(cauchy_boundP p_neq0) /ltr_normlP []; rewrite ltr_oppl.
 Qed.
 Hint Resolve le_cauchy_bound.
 
 Lemma ge_cauchy_bound p : p != 0 -> {in `[cauchy_bound p, +oo[, noroot p}.
 Proof.
-move=> p_neq0 x; rewrite inE andbT /= lerNgt; apply: contra => /rootP.
+move=> p_neq0 x; rewrite inE andbT /= leNgt; apply: contra => /rootP.
 by move=> /(cauchy_boundP p_neq0) /ltr_normlP []; rewrite ltr_oppl.
 Qed.
 Hint Resolve ge_cauchy_bound.
@@ -246,7 +245,7 @@ Qed.
 Hint Resolve cauchy_bound_gt0.
 
 Lemma cauchy_bound_ge0 p : cauchy_bound p >= 0.
-Proof. by rewrite ltrW. Qed.
+Proof. by rewrite ltW. Qed.
 Hint Resolve cauchy_bound_ge0.
 
 End CauchyBound.
@@ -278,15 +277,15 @@ Lemma polyrN0_itv (i : interval R) (p : {poly R}) :
   forall y x : R, y \in i -> x \in i -> sgr p.[x] = sgr p.[y].
 Proof.
 move=> hi y x hy hx; wlog xy: x y hx hy / x <= y=> [hwlog|].
-  by case/orP: (ler_total x y)=> xy; [|symmetry]; apply: hwlog.
+  by case/orP: (le_total x y)=> xy; [|symmetry]; apply: hwlog.
 have hxyi: {subset `[x, y] <= i}.
   move=> z; apply: subitvP=> /=.
-  by case: i hx hy {hi}=> [[[] ?|] [[] ?|]] /=; do ?[move/itvP->|move=> ?].
+  by case: i hx hy {hi}=> [[[] ?|] [[] ?|]] //= /itvP -> /itvP ->.
 do 2![case: sgrP; first by move/rootP; rewrite (negPf (hi _ _))]=> //.
-  move=> /ltrW py0 /ltrW p0x; case: (@poly_ivt (- p) x y)=> //.
+  move=> /ltW py0 /ltW p0x; case: (@poly_ivt (- p) x y)=> //.
     by rewrite inE /= !hornerN !oppr_cp0 p0x.
   by move=> z hz; rewrite rootN (negPf (hi z _)) // hxyi.
-move=> /ltrW p0y /ltrW px0; case: (@poly_ivt p x y); rewrite ?inE /= ?px0 //.
+move=> /ltW p0y /ltW px0; case: (@poly_ivt p x y); rewrite ?inE /= ?px0 //.
 by move=> z hz; rewrite (negPf (hi z _)) // hxyi.
 Qed.
 
@@ -321,18 +320,18 @@ move=> l0x.
 case: (ltrgtP x 1)=> hx; last by exists 1; rewrite ?hx ?lter01// expr1n.
   case: (@poly_ivt ('X ^+ n.+1 - x%:P) 0 1); first by rewrite ler01.
     rewrite ?(hornerE,horner_exp) ?inE /=.
-    by rewrite exprS mul0r sub0r expr1n oppr_cp0 subr_gte0/= !ltrW.
+    by rewrite exprS mul0r sub0r expr1n oppr_cp0 subr_gte0/= !ltW.
   move=> y; case/andP=> [/= l0y ly1]; rewrite rootE ?(hornerE,horner_exp).
   rewrite subr_eq0; move/eqP=> hyx; exists y=> //; rewrite lt0r l0y.
   rewrite andbT; apply/eqP=> y0; move: hyx; rewrite y0.
-  by rewrite exprS mul0r=> x0; move: l0x; rewrite -x0 ltrr.
-case: (@poly_ivt ('X ^+ n.+1 - x%:P) 0 x); first by rewrite ltrW.
+  by rewrite exprS mul0r=> x0; move: l0x; rewrite -x0 ltxx.
+case: (@poly_ivt ('X ^+ n.+1 - x%:P) 0 x); first by rewrite ltW.
   rewrite ?(hornerE,horner_exp) exprS mul0r sub0r ?inE /=.
-  by rewrite oppr_cp0 (ltrW l0x) subr_ge0 ler_eexpr // ltrW.
+  by rewrite oppr_cp0 (ltW l0x) subr_ge0 ler_eexpr // ltW.
 move=> y; case/andP=> /= l0y lyx; rewrite rootE ?(hornerE,horner_exp).
 rewrite subr_eq0; move/eqP=> hyx; exists y=> //; rewrite lt0r l0y.
 rewrite andbT; apply/eqP=> y0; move: hyx; rewrite y0.
-by rewrite exprS mul0r=> x0; move: l0x; rewrite -x0 ltrr.
+by rewrite exprS mul0r=> x0; move: l0x; rewrite -x0 ltxx.
 Qed.
 
 Lemma poly_cont x p e :
@@ -348,16 +347,16 @@ move=> d' d'p He'.
 case: (@nth_root (e / ((3%:R / 2%:R) * `|p.[x]|)) n).
   by rewrite ltr_pdivl_mulr ?mul0r ?pmulr_rgt0 ?invr_gt0 ?normrE ?ltr0Sn.
 move=> d dp rootd.
-exists (minr d d'); first by rewrite ltr_minr dp.
-move=> y; rewrite ltr_minr; case/andP=> hxye hxye'.
-rewrite !(hornerE, horner_exp) subrr [0 ^+ _]exprS mul0r mulr0 add0r addrK.
-rewrite normrM (@ler_lt_trans _  (`|p.[y]| * d ^+ n.+1)) //.
-  by rewrite ler_wpmul2l ?normrE // normrX ler_expn2r -?topredE /= ?normrE 1?ltrW.
+exists (minr d d'); first by rewrite ltxI dp.
+move=> y; rewrite ltxI; case/andP=> hxye hxye'.
+rewrite !(hornerE, horner_exp) subrr expr0n mulr0n mulr0 add0r addrK normrM.
+apply: le_lt_trans (_ : `|p.[y]| * d ^+ n.+1 < _).
+  by rewrite ler_wpmul2l ?normrE // normrX ler_expn2r -?topredE /= ?normrE 1?ltW.
 rewrite rootd mulrCA gtr_pmulr //.
 rewrite ltr_pdivr_mulr ?mul1r ?pmulr_rgt0 ?invr_gt0 ?ltr0Sn ?normrE //.
 rewrite mulrDl mulrDl divff; last by rewrite -mulr2n pnatr_eq0.
 rewrite !mul1r mulrC -ltr_subl_addr.
-by rewrite (ler_lt_trans _ (He' y _)) // ler_sub_dist.
+by rewrite (le_lt_trans _ (He' y _)) // ler_sub_dist.
 Qed.
 
 Lemma poly_ltsp_roots p (rs : seq R) :
@@ -375,7 +374,7 @@ move=> hab /eqP; rewrite mulrC mulr_sg_eqN1=> /andP [spb0 /eqP spb].
   by rewrite !hornerZ {1}spb mulNr -!normrEsg inE /= oppr_cp0 !normrE.
 move=> c hc; rewrite rootZ ?sgr_eq0 // => rpc; exists c=> //.
 (* need for a lemma reditvP *)
-rewrite inE /= !ltr_neqAle andbCA -!andbA [_ && (_ <= _)]hc andbT.
+rewrite inE /= !lt_neqAle andbCA -!andbA [_ && (_ <= _)]hc andbT.
 rewrite eq_sym -negb_or.
 apply/negP=> /orP [] /eqP ec; move: rpc; rewrite -ec /root ?(negPf spb0) //.
 by rewrite -sgr_cp0 -[sgr _]opprK -spb eqr_oppLR oppr0 sgr_cp0 (negPf spb0).
@@ -397,9 +396,9 @@ rewrite (contraNneq _ p'a0) /= in qb0 => [|->]; last exact: root0.
 case: m hp' pb0 p0 p'a0 qb0=> [|m].
   rewrite {1}expr0 mulr1=> ->; move/eqP.
   rewrite !(hornerE, horner_exp, mulf_eq0).
-  by rewrite !expf_eq0 !subr_eq0 !(gtr_eqF lab) !andbF !orbF !rootE=> ->.
+  by rewrite !expf_eq0 !subr_eq0 !(gt_eqF lab) !andbF !orbF !rootE=> ->.
 move=> -> _ p0 p'a0 qb0; case: (sgrP (q.[a] * q.[b])); first 2 last.
-- move=> sqasb; case: (@ivt_sign q a b)=> //; first exact: ltrW.
+- move=> sqasb; case: (@ivt_sign q a b)=> //; first exact: ltW.
     by apply/eqP; rewrite -sgrM sgr_cp0.
   move=> c lacb rqc; exists c=> //.
   by rewrite !hornerM (eqP rqc) !mul0r eqxx orbT.
@@ -414,7 +413,7 @@ move=> -> _ p0 p'a0 qb0; case: (sgrP (q.[a] * q.[b])); first 2 last.
     = (y * z * x) * (xbm * xan).
     by move=> x y z; rewrite mulrCA !mulrA [_ * y]mulrC mulrA.
   rewrite !fac -!mulrDl; set r := _ + _ + _.
-  case: (@ivt_sign (sgr q.[b] *: r) a b); first exact: ltrW.
+  case: (@ivt_sign (sgr q.[b] *: r) a b); first exact: ltW.
     rewrite !hornerZ !sgr_smul mulrACA -expr2 sqr_sg (rootPf qb0) mul1r.
     rewrite !(subrr, mul0r, mulr0, addr0, add0r, hornerC, hornerXsubC,
       hornerD, hornerN, hornerM, hornerMn).
@@ -444,7 +443,7 @@ case: (@rolle_weak a b p); rewrite // ?pa0 ?pb0 //=.
 move=> c hc; case: (altP (_ =P 0))=> //= p'c0 pc0; first by exists c.
 suff: { d : R | d \in `]a, c[ & (p^`()).[d] = 0 }.
   case=> [d hd] p'd0; exists d=> //.
-  by apply: subitvPr hd; rewrite //= (itvP hc).
+  by apply: subitvPr hd; rewrite /= (itvP hc).
 apply: ihn=> //; first by rewrite (itvP hc).
   exact/eqP.
 move=> rs hrs srs urs rrs; apply: (max_roots (c :: rs))=> //=; last exact/andP.
@@ -469,9 +468,9 @@ Qed.
 Lemma ler_hornerW a b p : (forall x, x \in `]a, b[ -> p^`().[x] >= 0) ->
   {in `[a, b] &, {homo horner p : x y / x <= y}}.
 Proof.
-move=> der_nneg x y axb ayb; rewrite ler_eqVlt => /orP[/eqP->//|ltxy].
+move=> der_nneg x y axb ayb; rewrite le_eqVlt => /orP[/eqP->//|ltxy].
 have [c xcy /(canRL (@subrK _ _))->]:= mvt p ltxy.
-rewrite ler_addr mulr_ge0 ?subr_ge0 ?(ltrW ltxy) ?der_nneg //.
+rewrite ler_addr mulr_ge0 ?subr_ge0 ?(ltW ltxy) ?der_nneg //.
 by apply: subitvP xcy; rewrite /= (itvP axb) (itvP ayb).
 Qed.
 
@@ -495,10 +494,10 @@ by apply: subitvP xcy; rewrite /= (itvP axb) (itvP ayb).
 Qed.
 
 Lemma ler_horner : {in `[a, b] &, {mono horner p : x y / x <= y}}.
-Proof. exact/ler_mono_in/ltr_hornerW. Qed.
+Proof. exact/le_mono_in/ltr_hornerW. Qed.
 
 Lemma ltr_horner : {in `[a, b] &, {mono horner p : x y / x < y}}.
-Proof. exact/lerW_mono_in/ler_horner. Qed.
+Proof. exact/leW_mono_in/ler_horner. Qed.
 
 Lemma derpr x : x \in `]a, b] -> p.[x] > p.[a].
 Proof.
@@ -554,26 +553,26 @@ Proof. by rewrite -sgr_cp0 sgp => /eqP->; rewrite mulrN1. Qed.
 
 Lemma ders0r : p.[a] = 0 -> forall x, x \in `]a, b] -> sgr p.[x] = sp'c.
 Proof.
-move=> pa0 x hx; rewrite hsgp // (ler_lt_trans _ (derq0r _)) //.
+move=> pa0 x hx; rewrite hsgp // (le_lt_trans _ (derq0r _)) //.
 by rewrite hornerZ pa0 mulr0.
 Qed.
 
 Lemma derspr : sgr p.[a] = sp'c -> forall x, x \in `[a, b] -> sgr p.[x] = sp'c.
 Proof.
-move=> spa x hx; rewrite hsgp // (ltr_le_trans _ (derqpr _)) //.
+move=> spa x hx; rewrite hsgp // (lt_le_trans _ (derqpr _)) //.
 by rewrite -sgr_cp0 hornerZ sgrM sgr_id spa -expr2 sqr_sg derp_neq0.
 Qed.
 
 Lemma ders0l : p.[b] = 0 -> forall x, x \in `[a, b[ -> sgr p.[x] = -sp'c.
 Proof.
-move=> pb0 x hx; rewrite hsgpN // (ltr_le_trans (derq0l _)) //.
+move=> pb0 x hx; rewrite hsgpN // (lt_le_trans (derq0l _)) //.
 by rewrite hornerZ pb0 mulr0.
 Qed.
 
 Lemma derspl :
   sgr p.[b] = -sp'c -> forall x, x \in `[a, b] -> sgr p.[x] = -sp'c.
 Proof.
-move=> spb x hx; rewrite hsgpN // (ler_lt_trans (derqnl _)) //.
+move=> spb x hx; rewrite hsgpN // (le_lt_trans (derqnl _)) //.
 by rewrite -sgr_cp0 hornerZ sgr_smul spb mulrN -expr2 sqr_sg derp_neq0.
 Qed.
 
@@ -595,10 +594,10 @@ by move=> x y axb ayb yx; rewrite -ltr_opp2 -!hornerN (ltr_hornerW dern_pos).
 Qed.
 
 Lemma ger_horner : {in `[a, b] &, {mono horner p : x y /~ x <= y}}.
-Proof. exact/ler_nmono_in/gtr_hornerW. Qed.
+Proof. exact/le_nmono_in/gtr_hornerW. Qed.
 
 Lemma gtr_horner : {in `[a, b] &, {mono horner p : x y /~ x < y}}.
-Proof. exact/lerW_nmono_in/ger_horner. Qed.
+Proof. exact/leW_nmono_in/ger_horner. Qed.
 
 Lemma dernr x : x \in `]a, b] -> p.[x] < p.[a].
 Proof.
@@ -640,10 +639,10 @@ case: (ivt_sign leab hs) => r arb pr0; exists r; split => //; last 2 first.
 - by move/eqP: pr0.
 - move=> x rxb; have hd : forall t, t \in `]r, b[ ->  0 < (p^`()).[t].
     by move=> t ht; rewrite der_pos // ?(subitvPl _ ht) //= ?(itvP arb).
-  by rewrite (ler_lt_trans _ (derpr hd _)) ?(eqP pr0).
+  by rewrite (le_lt_trans _ (derpr hd _)) ?(eqP pr0).
 - move=> x rxb; have hd : forall t, t \in `]a, r[ ->  0 < (p^`()).[t].
     by move=> t ht; rewrite der_pos // ?(subitvPr _ ht) //= ?(itvP arb).
-  by rewrite (ltr_le_trans (derpl hd _)) ?(eqP pr0).
+  by rewrite (lt_le_trans (derpl hd _)) ?(eqP pr0).
 Qed.
 
 End der_root.
@@ -749,16 +748,15 @@ rewrite hx (roots_on_root hxs) ?mem_head //.
 split=> // y; move: (hxs y); rewrite ?in_nil ?in_cons /=.
   case hy: (y \in `]a, x[)=> //=.
   rewrite (subitvPr _ hy) //= ?(itvP hx) //= => ->.
-  rewrite ltr_eqF ?(itvP hy) //=; apply/negP.
-  by move/allP: lxs=> lxs /lxs; rewrite ltrNge ?(itvP hy).
+  rewrite lt_eqF ?(itvP hy) //=; apply/negP.
+  by move/allP: lxs=> lxs /lxs; rewrite ?(itvP hy).
 move/allP:lxs=>lxs; case eyx: (y == _)=> /=.
   case/andP=> hy _; rewrite (eqP eyx).
   rewrite boundl_in_itv /=; symmetry.
-  by apply/negP; move/lxs; rewrite ltrr.
+  by apply/negP; move/lxs; rewrite ltxx.
 case py0: root; rewrite !(andbT, andbF) //.
 case ys: (y \in s); first by move/lxs:ys; rewrite ?inE /= => ->; case/andP.
-move/negP; move/negP=> nhy; apply: negbTE; apply: contra nhy.
-by apply: subitvPl; rewrite //= ?(itvP hx).
+by apply/contraFF/subitvPl; rewrite /= ?(itvP hx).
 Qed.
 
 Lemma max_roots_on p a b x s :
@@ -777,7 +775,7 @@ Lemma roots_on_cons p a b r s :
   sorted <%R (r :: s) -> roots_on p `]a, b[ (r :: s) -> roots_on p `]r, b[ s.
 Proof.
 move=> /= hrs hr.
-have:= (order_path_min (@ltr_trans _) hrs)=> allrs.
+have:= (order_path_min lt_trans hrs)=> allrs.
 by case: (min_roots_on allrs hr).
 Qed.
 (* move=> p a b r s hp hr x; apply/andP/idP. *)
@@ -797,7 +795,7 @@ Lemma roots_on_rcons : forall p a b r s,
 Proof.
 move=> p a b r s; rewrite -{1}[s]revK -!rev_cons rev_sorted /=.
 move=> hrs hr.
-have := (order_path_min (rev_trans (@ltr_trans _)) hrs)=> allrrs.
+have := (order_path_min (rev_trans lt_trans) hrs)=> allrrs.
 have allrs: (all (< r) s).
   by apply/allP=> x hx; move/allP:allrrs; apply; rewrite mem_rev.
 move/(@roots_on_same _ _ _ _ (r::s)):hr=>hr.
@@ -846,13 +844,13 @@ wlog {hp'} hp'sg: p / forall x, x \in `]a, b[ -> sgr (p^`()).[x] = 1.
 have hp'pos: forall x, x \in `]a, b[ -> (p^`()).[x] > 0.
   by move=> x; move/hp'sg; move/eqP; rewrite sgr_cp0.
 case: (lerP 0 p.[a]) => ha.
-- left; apply: no_roots_on => x axb; rewrite rootE gtr_eqF //.
-  by rewrite (ler_lt_trans _ (derpr hp'pos _))// (subitvPr _ axb) /=.
+- left; apply: no_roots_on => x axb; rewrite rootE gt_eqF //.
+  by rewrite (le_lt_trans _ (derpr hp'pos _))// (subitvPr _ axb) /=.
 - case: (lerP p.[b] 0) => hb.
   + left => x; rewrite in_nil; apply: negbTE; case axb: (x \in `]a, b[) => //=.
-    rewrite rootE ltr_eqF //.
-    by rewrite (ltr_le_trans (derpl hp'pos _)) // (subitvPl _ axb) /=.
-  + case: (derp_root hp'pos (ltrW leab) _).
+    rewrite rootE lt_eqF //.
+    by rewrite (lt_le_trans (derpl hp'pos _)) // (subitvPl _ axb) /=.
+  + case: (derp_root hp'pos (ltW leab) _).
       by rewrite ?inE; apply/andP.
   move=> r [h1 h2 h3] h4; right.
   exists r => x; rewrite in_cons in_nil (itv_splitU2 h3).
@@ -860,8 +858,8 @@ case: (lerP 0 p.[a]) => ha.
     by rewrite rootE (eqP exr) h2 eqxx.
   case px0: root; rewrite (andbT, andbF) //.
   move/eqP: px0=> px0; apply/negP; case/orP=> hx.
-    by move: (h1 x); rewrite (subitvPl _ hx) //= px0 ltrr; move/implyP.
-  by move: (h4 x); rewrite (subitvPr _ hx) //= px0 ltrr; move/implyP.
+    by move: (h1 x); rewrite (subitvPl _ hx) //= px0 ltxx; move/implyP.
+  by move: (h4 x); rewrite (subitvPr _ hx) //= px0 ltxx; move/implyP.
 Qed.
 
 (* Inductive polN0 : Type := PolN0 : forall p : {poly R}, p != 0 -> polN0. *)
@@ -890,7 +888,7 @@ move=> hx /= npx0 s; elim: s a hx => [|y s ihs] a hx s' //= ss ss'.
   rewrite (itv_splitU2 hx); case: (y \in `]x, b[); rewrite ?orbF ?orbT //=.
   apply/negP; case/orP; first by  move/hax; rewrite py0.
   by move/eqP=> exy; rewrite -exy py0 in npx0.
-move/min_roots_on; rewrite order_path_min //; last exact: ltr_trans.
+move/min_roots_on; rewrite order_path_min //; last exact: lt_trans.
 case=> // hy hay py0 hs hs' z.
 rewrite in_cons; case ezy: (z == y)=> /=.
   by rewrite (eqP ezy) py0 andbT (subitvPr _ hy) //= ?(itvP hx).
@@ -929,7 +927,7 @@ case: (ihn _ sizep' p'0 a b) => sp' ih {ihn}.
 case ltab : (a < b); last first.
   exists [::]; constructor=> // x; rewrite in_nil.
   case axb : (x \in _) => //=.
-  by case/andP: axb => ax xb; move: ltab; rewrite (ltr_trans ax xb).
+  by case/andP: axb => ax xb; move: ltab; rewrite (lt_trans ax xb).
 elim: sp' a b ltab ih => [|r1 sp' hsp'] a b ltab hp'.
   case: hp' np'0; rewrite ?eqxx // =>  np'0 hroots' _ _.
   move/roots_on_nil : hroots' => hroots'.
@@ -938,7 +936,7 @@ elim: sp' a b ltab ih => [|r1 sp' hsp'] a b ltab hp'.
   by exists [:: r]; constructor=> //=; rewrite andbT.
 case: hp' np'0; rewrite ?eqxx // => np'0 hroots' /= hpath' _.
 case: (min_roots_on _ hroots').
-  by rewrite order_path_min //; apply: ltr_trans.
+  by rewrite order_path_min //; apply: lt_trans.
 move=> hr1 har1 p'r10 hr1b.
 case: (hsp' r1 b); first by rewrite (itvP hr1).
   by constructor=> //; rewrite (path_sorted hpath').
@@ -951,12 +949,12 @@ case pr1 : (root p r1); case/monotonic_rootN => hrootsl; last 2 first.
   by rewrite -[s]cat0s; apply: (cat_roots_on hr1)=> //; rewrite pr1.
 - case: hrootsl=> r hr; exists (r::s); constructor=> //=.
     by rewrite -cat1s; apply: (cat_roots_on hr1)=> //; rewrite pr1.
-  rewrite path_min_sorted //; first [move=> y | apply/allP => y].
-  rewrite -hroot; case/andP=> hy _; rewrite (@ltr_trans _ r1) ?(itvP hy) //.
+  rewrite path_min_sorted //; apply/allP=> y; rewrite -hroot; case/andP=> hy _.
+  rewrite (lt_trans (_ : _ < r1)) ?(itvP hy) //.
   by rewrite (itvP (roots_on_in hr (mem_head _ _))).
 - exists (r1::s); constructor=> //=; last first.
-    rewrite path_min_sorted //; first [move=> y | apply/allP => y].
-    by rewrite -hroot; case/andP; move/itvP->.
+    rewrite path_min_sorted //; apply/allP => y; rewrite -hroot.
+    by case/andP; move/itvP->.
   move=> x; rewrite in_cons; case exr1: (x == r1)=> /=.
     by rewrite (eqP exr1) pr1 andbT.
   rewrite -hroot; case px: root; rewrite ?(andbT, andbF) //.
@@ -966,9 +964,8 @@ case pr1 : (root p r1); case/monotonic_rootN => hrootsl; last 2 first.
 - case: hrootsl => r0 hrootsl.
   move/min_roots_on:hrootsl; case=> // hr0 har0 pr0 hr0r1.
   exists [:: r0, r1 & s]; constructor=> //=; last first.
-    rewrite (itvP hr0) /=.
-    rewrite path_min_sorted //; first [move=> y | apply/allP => y].
-    by rewrite -hroot; case/andP; move/itvP->.
+    rewrite (itvP hr0) /= path_min_sorted //; apply/allP=> y.
+    by rewrite -hroot; case/andP => /itvP ->.
   move=> y; rewrite !in_cons (itv_splitU2 hr1) (itv_splitU2 hr0).
   case eyr0: (y == r0); rewrite ?(orbT, orbF, orTb, orFb).
     by rewrite (eqP eyr0) pr0.
@@ -1000,9 +997,8 @@ Hint Resolve sorted_roots.
 
 Lemma path_roots p a b : path <%R a (roots p a b).
 Proof.
-case: rootsP=> //= p0 hp sp.
-rewrite path_min_sorted //; first [move=> y | apply/allP => y].
-by rewrite -hp; case/andP; move/itvP->.
+case: rootsP=> //= p0 hp sp; rewrite path_min_sorted //.
+by apply/allP=> y; rewrite -hp; case/andP => /itvP ->.
 Qed.
 Hint Resolve path_roots.
 
@@ -1047,14 +1043,12 @@ elim: s1 p a b s2 => [| r1 s1 ih] p a b [| r2 s2] ps1 ps2 rs1 rs2 //.
 - have er1r2 : r1 = r2.
     move: (rs1 r2); rewrite (roots_on_root rs2) ?mem_head //.
     rewrite !(roots_on_in rs2) ?mem_head //= in_cons.
-    move/(@sym_eq _ true); case/orP => hr2; first by rewrite (eqP hr2).
-    move: ps1=> /=; move/(order_path_min (@ltr_trans R)); move/allP.
-    move/(_ r2 hr2) => h1.
+    case/(@sym_eq _ true)/orP => [/eqP -> //|hr2].
+    move/(order_path_min lt_trans)/allP/(_ r2 hr2): ps1 => h1.
     move: (rs2 r1); rewrite (roots_on_root rs1) ?mem_head //.
     rewrite !(roots_on_in rs1) ?mem_head //= in_cons.
-    move/(@sym_eq _ true); case/orP => hr1; first by rewrite (eqP hr1).
-    move: ps2=> /=; move/(order_path_min (@ltr_trans R)); move/allP.
-    by move/(_ r1 hr1); rewrite ltrNge ltrW.
+    case/(@sym_eq _ true)/orP => [/eqP -> //|hr1].
+    by move/(order_path_min lt_trans)/allP/(_ r1 hr1): ps2; rewrite ltNge ltW.
 congr (_ :: _) => //; rewrite er1r2 in ps1 rs1.
 have h3 := (roots_on_cons ps1 rs1).
 have h4 := (roots_on_cons ps2 rs2).
@@ -1068,9 +1062,9 @@ Lemma roots_eq (p q : {poly R}) (a b : R) :
 Proof.
 move=> p0 q0.
 case hab : (a < b); last first.
-  split; first by rewrite !rootsEba // lerNgt hab.
+  split; first by rewrite !rootsEba // leNgt hab.
   move=> _ x. rewrite !inE; case/andP=> ax xb.
-  by move: hab; rewrite (@ltr_trans _ x) /=.
+  by move: hab; rewrite (lt_trans ax).
 split=> hpq.
   apply: (@roots_on_uniq p a b); rewrite ?path_roots ?p0 ?q0 //.
     by apply: roots_on_roots.
@@ -1132,7 +1126,7 @@ Proof.
 case: rootsP=> // p0 hs' ps' /=.
 apply/idP/idP.
   move/eqP=> es'; move: ps' hs'; rewrite es' /= => sxs.
-  case/min_roots_on; first by apply: order_path_min=> //; apply: ltr_trans.
+  case/min_roots_on; first by apply: order_path_min=> //; apply: lt_trans.
   move=> -> rax px0 rxb.
   rewrite px0 (@roots_uniq p a x [::]) // (@roots_uniq p x b s) ?eqxx //=.
   by move/path_sorted:sxs.
@@ -1141,8 +1135,8 @@ case/and3P=> hx hax; rewrite (eqP hax) in rax sax.
 case: rootsP p0=> // p0 rxb sxb _.
 case/andP=> px0 hxb; rewrite (eqP hxb) in rxb sxb.
 rewrite [_ :: _](@roots_uniq p a b) //; last first.
-  rewrite /= path_min_sorted //; first [move=> y | apply/allP => y].
-  by rewrite -(eqP hxb); move/roots_in; move/itvP->.
+  rewrite /= path_min_sorted //; apply/allP => y.
+  by rewrite -(eqP hxb); move/roots_in/itvP->.
 move=> y; rewrite (itv_splitU2 hx) !andb_orl in_cons.
 case hy: (y == x); first by rewrite (eqP hy) px0 orbT.
 by rewrite andFb orFb rax rxb in_nil.
@@ -1162,7 +1156,7 @@ apply/idP/idP.
   move/(roots_on_same _ _ hsx).
   case/max_roots_on.
     move: sxs; rewrite -[rcons _ _]revK rev_sorted rev_rcons.
-    by apply: order_path_min=> u v w /=; move/(ltr_trans _); apply.
+    by apply: order_path_min=> u v w /=; move/(lt_trans _); apply.
   move=> -> rax px0 rxb.
   move/(@roots_on_same _ s): rxb; move/(_ (mem_rev _))=> rxb.
   rewrite px0 (@roots_uniq p x b [::]) // (@roots_uniq p a x s) ?eqxx //=.
@@ -1173,10 +1167,10 @@ case/and3P=> hx hax; rewrite (eqP hax) in rax sax.
 case: rootsP p0=> // p0 rxb sxb _.
 case/andP=> px0 hxb; rewrite (eqP hxb) in rxb sxb.
 rewrite [rcons _ _](@roots_uniq p a b) //; last first.
-  rewrite -[rcons _ _]revK rev_sorted rev_rcons /=.
-  rewrite path_min_sorted; [by rewrite -rev_sorted revK|].
-  first [move=> y | apply/allP => y]; rewrite mem_rev; rewrite -(eqP hxb).
-  by move/roots_in; move/itvP->.
+  rewrite -[rcons _ _]revK rev_sorted rev_rcons /= path_min_sorted.
+    by rewrite -rev_sorted revK.
+  apply/allP=> y; rewrite mem_rev; rewrite -(eqP hxb).
+  by move/roots_in/itvP->.
 move=> y; rewrite (itv_splitU2 hx) mem_rcons in_cons !andb_orl.
 case hy: (y == x); first by rewrite (eqP hy) px0 orbT.
 by rewrite rxb rax in_nil !orbF.
@@ -1216,9 +1210,9 @@ Qed.
 Lemma next_root_in p a b : next_root p a b \in `[a, maxr b a].
 Proof.
 case: next_rootP => [p0|y np0 py0 hy _|c np0 hc _].
-* by rewrite bound_in_itv /= ler_maxr lerr orbT.
-* by apply: subitvP hy=> /=; rewrite ler_maxr !lerr.
-* by rewrite hc bound_in_itv /= ler_maxr lerr orbT.
+* by rewrite bound_in_itv /= lexU lexx orbT.
+* by apply: subitvP hy=> /=; rewrite lexU !lexx.
+* by rewrite hc bound_in_itv /= lexU lexx orbT.
 Qed.
 
 Lemma next_root_gt p a b : a < b -> p != 0 -> next_root p a b > a.
@@ -1226,7 +1220,7 @@ Proof.
 move=> ab np0; case: next_rootP=> [p0|y _ py0 hy _|c _ -> _].
 * by rewrite p0 eqxx in np0.
 * by rewrite (itvP hy).
-* by rewrite maxr_l // ltrW.
+* by rewrite ltxU ab.
 Qed.
 
 Lemma next_noroot p a b : {in `]a, (next_root p a b)[, noroot p}.
@@ -1234,7 +1228,7 @@ Proof.
 move=> z; case: next_rootP; first by rewrite itv_xx.
   by move=> y np0 py0 hy hp hz; rewrite (negPf (hp _ _)).
 move=> c p0 -> hp hz; rewrite (negPf (hp _ _)) //.
-by case: maxrP hz; last by rewrite itv_xx.
+by case: leP hz; first rewrite itv_xx.
 Qed.
 
 Lemma is_next_root p a b x :
@@ -1244,10 +1238,10 @@ case; first by move->; rewrite /next_root eqxx.
   move=> y; case: next_rootP; first by move->; rewrite eqxx.
   move=> y' np0 py'0 hy' hp' _ py0 hy hp.
     wlog: y y' hy' hy hp' hp py0 py'0 / y <= y'.
-      by case/orP: (ler_total y y')=> lyy' hw; [|symmetry]; apply: hw.
+      by case/orP: (le_total y y')=> lyy' hw; [|symmetry]; apply: hw.
     case: ltrgtP=> // hyy' _; move: (hp' y).
     by rewrite rootE py0 eqxx inE /= (itvP hy) hyy'; move/(_ isT).
-  move=> c p0 ->; case: maxrP=> hab; last by rewrite itv_gte //= ltrW.
+  move=> c p0 ->; case: leP => hba; first by rewrite itv_gte.
   by move=> hpz _ py0 hy; move/hpz:hy; rewrite rootE py0 eqxx.
 case: next_rootP => //; first by move->; rewrite eqxx.
   by move=> y np0 py0 hy _ c _ _; move/(_ _ hy); rewrite rootE py0 eqxx.
@@ -1284,16 +1278,16 @@ Qed.
 Lemma prev_root_in p a b : prev_root p a b \in `[minr a b, b].
 Proof.
 case: prev_rootP => [p0|y np0 py0 hy _|c np0 hc _].
-* by rewrite bound_in_itv /= ler_minl lerr orbT.
-* by apply: subitvP hy=> /=; rewrite ler_minl !lerr.
-* by rewrite hc bound_in_itv /= ler_minl lerr orbT.
+* by rewrite bound_in_itv /= leIx lexx orbT.
+* by apply: subitvP hy=> /=; rewrite leIx !lexx.
+* by rewrite hc bound_in_itv /= leIx lexx orbT.
 Qed.
 
 Lemma prev_noroot p a b : {in `](prev_root p a b), b[, noroot p}.
 Proof.
 move=> z; case: prev_rootP; first by rewrite itv_xx.
   by move=> y np0 py0 hy hp hz; rewrite (negPf (hp _ _)).
-move=> c np0 ->; case: minrP=> hab; last by rewrite itv_xx.
+move=> c np0 ->; case: leP=> hab; last by rewrite itv_xx.
 by move=> hp hz; rewrite (negPf (hp _ _)).
 Qed.
 
@@ -1302,7 +1296,7 @@ Proof.
 move=> ab np0; case: prev_rootP=> [p0|y _ py0 hy _|c _ -> _].
 * by rewrite p0 eqxx in np0.
 * by rewrite (itvP hy).
-* by rewrite minr_l // ltrW.
+* by rewrite ltIx ab.
 Qed.
 
 Lemma is_prev_root p a b x :
@@ -1312,13 +1306,13 @@ case; first by move->; rewrite /prev_root eqxx.
   move=> y; case: prev_rootP; first by move->; rewrite eqxx.
   move=> y' np0 py'0 hy' hp' _ py0 hy hp.
     wlog: y y' hy' hy hp' hp py0 py'0 / y <= y'.
-      by case/orP: (ler_total y y')=> lyy' hw; [|symmetry]; apply: hw.
+      by case/orP: (le_total y y')=> lyy' hw; [|symmetry]; apply: hw.
     case: ltrgtP=> // hyy' _; move/implyP: (hp y').
     by rewrite rootE py'0 eqxx inE /= (itvP hy') hyy'.
   by move=> c _ _ hpz _ py0 hy; move/hpz:hy; rewrite rootE py0 eqxx.
 case: prev_rootP=> //; first by move->; rewrite eqxx.
-  move=> y ? py0 hy _ c _ ->; case: minrP hy=> hab; last first.
-    by rewrite itv_gte //= ltrW.
+  move=> y ? py0 hy _ c _ ->.
+  case: ltP hy=> hab; last by rewrite itv_gte.
   by move=> hy; move/(_ _ hy); rewrite rootE py0 eqxx.
 by move=> c  _ -> _ c' _ ->.
 Qed.
@@ -1374,7 +1368,7 @@ Qed.
 Lemma uniq_roots a b p : uniq (roots p a b).
 Proof.
 case p0: (p == 0); first by rewrite (eqP p0) roots0.
-by apply: (@sorted_uniq _ <%R); [apply: ltr_trans | apply: ltrr|].
+by apply: (@sorted_uniq _ <%R); [apply: lt_trans | apply: ltxx|].
 Qed.
 
 Hint Resolve uniq_roots.
@@ -1390,15 +1384,12 @@ Qed.
 Lemma gdcop_eq0 p q : (gdcop p q == 0) = (q == 0) && (p != 0).
 Proof.
 case: (eqVneq q 0) => [-> | q0].
-  rewrite gdcop0 /=.
-  by have [|] := (boolP (p == 0)) => [p0| pn0] /=; rewrite ?eqxx ?oner_eq0.
+  by rewrite gdcop0 /=; case: (eqVneq p 0) => _; rewrite ?eqxx ?oner_eq0.
 rewrite /gdcop; move: {-1}(size q) (leqnn (size q))=> k hk.
-case (eqVneq p 0) => [-> | p0].
-  rewrite ?eqxx andbF; apply: negPf.
+case: (eqVneq p 0) => [-> | p0] /=; apply: negPf.
   elim: k q q0 {hk} => [|k ihk] q q0 /=; first by rewrite eqxx oner_eq0.
   case: ifP => _ //.
   by apply: ihk; rewrite gcdp0 divpp ?q0 // polyC_eq0; apply/lc_expn_scalp_neq0.
-rewrite ?(negbTE q0) andFb; apply: negPf.
 elim: k q q0 hk => [|k ihk] /= q q0 hk.
   by move: hk q0; rewrite leqn0 size_poly_eq0; move->.
 case: ifP=> cpq; first by rewrite (negPf q0).
@@ -1424,7 +1415,7 @@ Lemma roots_mul a b : a < b -> forall p q,
   (roots p a b ++ roots ((gdcop p q)) a b).
 Proof.
 move=> hab p q np0 nq0.
-apply: uniq_perm_eq; first exact: uniq_roots.
+apply: uniq_perm; first exact: uniq_roots.
   rewrite cat_uniq ?uniq_roots andbT /=; apply/hasPn=> x /=.
   move/root_roots; rewrite root_gdco //; case/andP=> _.
   by rewrite in_roots !negb_and=> ->.
@@ -1441,8 +1432,8 @@ Lemma roots_mul_coprime a b :
   (roots p a b ++ roots q a b).
 Proof.
 move=> hab p q np0 nq0 cpq.
-rewrite (perm_eq_trans (roots_mul hab np0 nq0)) //.
-suff ->: roots (gdcop p q) a b = roots q a b by apply: perm_eq_refl.
+rewrite (perm_trans (roots_mul hab np0 nq0)) //.
+suff ->: roots (gdcop p q) a b = roots q a b by apply: perm_refl.
 case: gdcopP=> r rq hrp; move/(_ q (dvdpp _)).
 rewrite coprimep_sym; move/(_ cpq)=> qr.
 have erq : r %= q by rewrite /eqp rq qr.
@@ -1457,9 +1448,9 @@ Lemma next_rootM a b (p q : {poly R}) :
 Proof.
 symmetry; apply: is_next_root.
 wlog: p q / next_root p a b <= next_root q a b.
-  case: minrP=> hpq; first by move/(_ _ _ hpq); case: minrP hpq.
-  by move/(_ _ _ (ltrW hpq)); rewrite mulrC minrC; case: minrP hpq.
-case: minrP=> //; case: next_rootP=> [|y np0 py0 hy|c np0 ->] hp hpq _.
+  case: leP=> hpq; first by move/(_ _ _ hpq); case: leP hpq.
+  by move/(_ _ _ (ltW hpq)); rewrite mulrC; case: ltP hpq.
+case: leP => //; case: next_rootP=> [|y np0 py0 hy|c np0 ->] hp hpq _.
 * by rewrite hp mul0r root0; constructor.
 * rewrite rootM; move/rootP:(py0)->; constructor=> //.
   - by rewrite mulf_neq0 //; case: next_rootP hpq; rewrite // (itvP hy).
@@ -1467,19 +1458,19 @@ case: minrP=> //; case: next_rootP=> [|y np0 py0 hy|c np0 ->] hp hpq _.
   - move=> z hz /=; rewrite rootM negb_or ?hp //.
     by rewrite (@next_noroot _ a b) //; apply: subitvPr hz.
 * case: (altP (q =P 0))=> q0.
-    move: hpq; rewrite q0 mulr0 root0 next_root0 ler_maxl lerr andbT.
-    by move=> hba; rewrite maxr_r //; constructor.
+    move: hpq; rewrite q0 mulr0 root0 next_root0 leUx lexx andbT.
+    by move/join_r => ->; constructor.
   constructor=> //; first by rewrite mulf_neq0.
   move=> z hz /=; rewrite rootM negb_or ?hp //.
   rewrite (@next_noroot _ a b) //; apply: subitvPr hz=> /=.
-  by move: hpq; rewrite ler_maxl; case/andP.
+  by move: hpq; rewrite leUx; case/andP.
 Qed.
 
 Lemma neighpr_mul a b p q :
   (neighpr (p * q) a b) =i [predI (neighpr p a b) & (neighpr q a b)].
 Proof.
 move=> x; rewrite inE /= !inE /= next_rootM.
-by case: (a < x); rewrite // ltr_minr.
+by case: (a < x); rewrite // ltxI.
 Qed.
 
 Lemma prev_rootM a b (p q : {poly R}) :
@@ -1487,9 +1478,9 @@ Lemma prev_rootM a b (p q : {poly R}) :
 Proof.
 symmetry; apply: is_prev_root.
 wlog: p q / prev_root p a b >= prev_root q a b.
-  case: maxrP=> hpq; first by move/(_ _ _ hpq); case: maxrP hpq.
-  by move/(_ _ _ (ltrW hpq)); rewrite mulrC maxrC; case: maxrP hpq.
-case: maxrP=> //; case: (@prev_rootP p)=> [|y np0 py0 hy|c np0 ->] hp hpq _.
+  case: leP=> hpq; last by move/(_ _ _ (ltW hpq)); case: leP hpq.
+  by move/(_ _ _ hpq); case: ltP hpq; rewrite mulrC.
+case: ltP => //; case: (@prev_rootP p)=> [|y np0 py0 hy|c np0 ->] hp hpq _.
 * by rewrite hp mul0r root0; constructor.
 * rewrite rootM; move/rootP:(py0)->; constructor=> //.
   - by rewrite mulf_neq0 //; case: prev_rootP hpq; rewrite // (itvP hy).
@@ -1497,19 +1488,19 @@ case: maxrP=> //; case: (@prev_rootP p)=> [|y np0 py0 hy|c np0 ->] hp hpq _.
   - move=> z hz /=; rewrite rootM negb_or ?hp //.
     by rewrite (@prev_noroot _ a b) //; apply: subitvPl hz.
 * case: (altP (q =P 0))=> q0.
-    move: hpq; rewrite q0 mulr0 root0 prev_root0 ler_minr lerr andbT.
-    by move=> hba; rewrite minr_r //; constructor.
+    move: hpq; rewrite q0 mulr0 root0 prev_root0 lexI lexx andbT.
+    by move/meet_r => ->; constructor.
   constructor=> //; first by rewrite mulf_neq0.
   move=> z hz /=; rewrite rootM negb_or ?hp //.
   rewrite (@prev_noroot _ a b) //; apply: subitvPl hz=> /=.
-  by move: hpq; rewrite ler_minr; case/andP.
+  by move: hpq; rewrite lexI; case/andP.
 Qed.
 
 Lemma neighpl_mul a b p q :
   (neighpl (p * q) a b) =i [predI (neighpl p a b) & (neighpl q a b)].
 Proof.
 move=> x; rewrite !inE /= prev_rootM.
-by case: (x < b); rewrite // ltr_maxl !(andbT, andbF).
+by case: (x < b); rewrite // ltUx !(andbT, andbF).
 Qed.
 
 Lemma neighpr_wit p x b : x < b -> p != 0 -> {y | y \in neighpr p x b}.
@@ -1561,7 +1552,7 @@ move=> y; rewrite /neighpr=> hy /=.
 case: (@neighpr_wit (p * p^`()) x b)=> [||m hm].
 * case: next_rootP hy; first by rewrite itv_xx.
     by move=> ? ? ?; move/itvP->.
-  by move=> c p0 -> _; case: maxrP=> _; rewrite ?itv_xx //; move/itvP->.
+  move=> c p0 -> _; first by case: leP; rewrite ?itv_xx.
 * rewrite mulf_neq0 //.
     by move/eqP:sp; apply: contraTneq=> ->; rewrite size_poly0.
   (* Todo : a lemma for this *)
@@ -1575,7 +1566,7 @@ case: (@neighpr_wit (p * p^`()) x b)=> [||m hm].
     move=> u hu /=; rewrite (@next_noroot _ x b) //.
     by apply: subitvPr hu; rewrite /= (itvP hmp').
   rewrite ihn ?size_deriv ?sp /neighpr //.
-  by rewrite (subitvP _ (@mid_in_itv _ true true _ _ _)) //= ?lerr (itvP hmp').
+  by rewrite (subitvP _ (@mid_in_itv _ true true _ _ _)) //= ?lexx (itvP hmp').
 Qed.
 
 Lemma sgr_neighpl a p x :
@@ -1605,7 +1596,7 @@ move=> y; rewrite /neighpl=> hy /=.
 case: (@neighpl_wit (p * p^`()) a x)=> [||m hm].
 * case: prev_rootP hy; first by rewrite itv_xx.
     by move=> ? ? ?; move/itvP->.
-  by move=> c p0 -> _; case: minrP=> _; rewrite ?itv_xx //; move/itvP->.
+  move=> c p0 -> _; first by case: ltP; rewrite ?itv_xx.
 * rewrite mulf_neq0 //.
     by move/eqP:sp; apply: contraTneq=> ->; rewrite size_poly0.
   (* Todo : a lemma for this *)
@@ -1620,7 +1611,7 @@ case: (@neighpl_wit (p * p^`()) a x)=> [||m hm].
     by apply: subitvPl hu; rewrite /= (itvP hmp').
   rewrite ihn ?size_deriv ?sp /neighpl //; last first.
     by rewrite (subitvP _ (@mid_in_itv _ true true _ _ _)) //=
-       ?lerr (itvP hmp').
+       ?lexx (itvP hmp').
   rewrite mu_deriv // odd_sub ?mu_gt0 //=; last by rewrite -size_poly_eq0 sp.
   by rewrite signr_addb /= mulrN1 mulNr opprK.
 Qed.
@@ -1799,10 +1790,10 @@ Lemma rootsRP p a b :
 Proof.
 move=> rpa rpb.
 have [->|p_neq0] := eqVneq p 0; first by rewrite rootsR0 roots0.
-apply: (eq_sorted_irr (@ltr_trans _)); rewrite ?sorted_roots // => x.
+apply: (eq_sorted_irr lt_trans); rewrite ?sorted_roots // => x.
 rewrite -roots_on_rootsR -?roots_on_roots //=.
 have [rpx|] := boolP (root _ _); rewrite ?(andbT, andbF) //.
-apply: contraLR rpx; rewrite inE negb_and -!lerNgt.
+apply: contraLR rpx; rewrite inE negb_and -!leNgt.
 by move=> /orP[/rpa //|xb]; rewrite rpb // inE andbT.
 Qed.
 
@@ -1817,9 +1808,9 @@ rewrite /sgp_pinfty; wlog lp_gt0 : x p / lead_coef p > 0 => [hwlog|rpx y Hy].
   by rewrite hornerN !sgrN Hp => // z /HNp; rewrite rootN.
 have [z Hz] := poly_pinfty_gt_lc lp_gt0.
 have {Hz} Hz u : u \in `[z, +oo[ -> Num.sg p.[u] = 1.
-  by rewrite inE andbT => /Hz pu_ge1; rewrite gtr0_sg // (ltr_le_trans lp_gt0).
-rewrite (@polyrN0_itv _ _ rpx (maxr y z)) ?inE /= ?ler_maxr ?(itvP Hy) //.
-by rewrite Hz ?gtr0_sg // inE /= ler_maxr lerr orbT.
+  by rewrite inE andbT => /Hz pu_ge1; rewrite gtr0_sg // (lt_le_trans lp_gt0).
+rewrite (@polyrN0_itv _ _ rpx (maxr y z)) ?inE /= ?lexU ?(itvP Hy) //.
+by rewrite Hz ?gtr0_sg // inE /= lexU lexx orbT.
 Qed.
 
 Lemma sgp_minftyP x (p : {poly R}) :

--- a/theories/qe_rcf.v
+++ b/theories/qe_rcf.v
@@ -6,7 +6,7 @@ Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp
 Require Import finfun path matrix.
 From mathcomp
-Require Import bigop ssralg poly polydiv ssrnum zmodp div ssrint.
+Require Import bigop order ssralg poly polydiv ssrnum zmodp div ssrint.
 From mathcomp
 Require Import polyorder polyrcf interval polyXY.
 From mathcomp
@@ -16,7 +16,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
 
 Local Open Scope nat_scope.
 Local Open Scope ring_scope.
@@ -611,7 +611,7 @@ Lemma eval_Changes e s k : qf_eval e (Changes s k)
   = qf_eval e (k (changes (map (eval e) s))).
 Proof.
 elim: s k=> //= a q ihq k; rewrite ihq eval_If /= -nth0.
-by case: q {ihq}=> /= [|b q]; [rewrite /= mulr0 ltrr add0n | case: ltrP].
+by case: q {ihq}=> /= [|b q]; [rewrite /= mulr0 ltxx add0n | case: ltrP].
 Qed.
 
 Lemma eval_SeqPInfty e ps k k' :

--- a/theories/qe_rcf_th.v
+++ b/theories/qe_rcf_th.v
@@ -128,7 +128,7 @@ have [Hpq|Hpq|Hpq] := (ltngtP (\mu_x p) (\mu_x q)).
 + by rewrite mu_addl ?geq_minr.
 have [//|p' nrp'x hp] := (@mu_spec _ p x).
 have [//|q' nrq'x hq] := (@mu_spec _ q x).
-rewrite Hpq minnn hp {1 3}hq Hpq -mulrDl => pq0.
+rewrite Hpq hp {1 3}hq Hpq -mulrDl => pq0.
 by rewrite mu_mul // mu_exp mu_XsubC mul1n leq_addl.
 Qed.
 
@@ -678,7 +678,7 @@ Proof.
 have [lt_ab r0|le_ba] := ltrP a b; last by rewrite !cindexEba.
 have [->|p0] := eqVneq p 0; first by rewrite mul0r !cindex0p.
 have [->|q0] := eqVneq q 0; first by rewrite mul0r !cindexpC.
-rewrite /cindex (eq_big_perm _ (roots_mul _ _ _))//= big_cat/=.
+rewrite /cindex (perm_big _ (roots_mul _ _ _))//= big_cat/=.
 rewrite -[\sum_(x <- _) jump p _ _]addr0; congr (_+_).
   by rewrite !big_seq; apply: congr_big => // x hx; rewrite jump_mul2r.
 rewrite big1_seq//= => x hx; rewrite jump_mul2r // /jump.
@@ -785,7 +785,7 @@ have jumpP : forall (p q : {poly R}), p != 0 -> coprimep p q  ->
 rewrite !(eq_bigr _ (jumpP _ _ _ _))// 1?coprimep_sym// => {jumpP}.
 have sjumpC x : sjump (q * p) x = sjump (p * q) x by rewrite mulrC.
 rewrite -!big_seq (eq_bigr _ (fun x _ => sjumpC x)).
-rewrite -big_cat /= -(eq_big_perm _ (roots_mul_coprime _ _ _ _)) //=.
+rewrite -big_cat /= -(perm_big _ (roots_mul_coprime _ _ _ _)) //=.
 move: {1 2 5}a hab (erefl (roots (p * q) a b)) => //=.
 elim: roots => {a} [|x s /= ihs] a hab /eqP.
   by rewrite big_cons !big_nil variation0r.

--- a/theories/qe_rcf_th.v
+++ b/theories/qe_rcf_th.v
@@ -4,7 +4,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp
 Require Import ssrfun ssrbool eqtype ssrnat seq choice path fintype.
 From mathcomp
-Require Import div bigop ssralg poly polydiv ssrnum perm zmodp ssrint.
+Require Import div bigop order ssralg poly polydiv ssrnum perm zmodp ssrint.
 From mathcomp
 Require Import polyorder polyrcf interval matrix mxtens.
 
@@ -12,7 +12,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GRing.Theory Num.Theory Num.Def Pdiv.Ring Pdiv.ComRing.
+Import Order.TTheory GRing.Theory Num.Theory Num.Def Pdiv.Ring Pdiv.ComRing.
 
 Local Open Scope nat_scope.
 Local Open Scope ring_scope.
@@ -540,8 +540,8 @@ Lemma sum_varP s : 0 \notin s -> sum_var s = variation (head 0 s) (last 0 s).
 Proof.
 rewrite /sum_var /variation.
 case: s => /= [_|a s]; first by rewrite big_nil sgz0 mul0r.
-rewrite in_cons big_cons mul0r ltrr mulr0 add0r.
-elim: s a => [|b s IHs] a; first by rewrite big_nil ler_gtF ?mulr0 ?sqr_ge0.
+rewrite in_cons big_cons mul0r ltxx mulr0 add0r.
+elim: s a => [|b s IHs] a; first by rewrite big_nil le_gtF ?mulr0 ?sqr_ge0.
 move=> /norP [neq_0a Hbs]; move: (Hbs); rewrite in_cons => /norP[neq_0b Hs].
 rewrite /= big_cons IHs ?negb_or ?neq_0b // -!sgz_cp0 !sgzM.
 have: (last b s) != 0 by apply: contra Hbs => /eqP <-; rewrite mem_last.
@@ -615,7 +615,7 @@ have [->|q0] := eqVneq q 0; first by rewrite !jumppc mulr0.
 rewrite /jump scale_poly_eq0 mu_mulC ?negb_or ?c0 ?p0 ?andTb //.
 rewrite -scalerAl sgp_right_scale //.
 case: sgzP c0 => // _ _; rewrite !(mul1r, mulN1r, =^~ mulNrn) //.
-by rewrite ?oppr_cp0 lt0r sgp_right_eq0 ?mulf_neq0 // andTb lerNgt signrN.
+by rewrite ?oppr_cp0 lt0r sgp_right_eq0 ?mulf_neq0 // andTb leNgt signrN.
 Qed.
 
 Lemma jump_pmulC c p q x : jump p (c *: q) x = (sgz c) * jump p q x.
@@ -625,7 +625,7 @@ have [->|p0] := eqVneq p 0; first by rewrite !jump0p mulr0.
 have [->|q0] := eqVneq q 0; first by rewrite scaler0 !jumppc mulr0.
 rewrite /jump mu_mulC // -scalerAr sgp_right_scale //.
 case: sgzP c0 => // _ _; rewrite !(mul1r, mulN1r, =^~ mulNrn) //.
-by rewrite ?oppr_cp0 lt0r sgp_right_eq0 ?mulf_neq0 // andTb lerNgt signrN.
+by rewrite ?oppr_cp0 lt0r sgp_right_eq0 ?mulf_neq0 // andTb leNgt signrN.
 Qed.
 
 Lemma jump_mod p q x :
@@ -720,7 +720,7 @@ by rewrite /cindex big_distrr; apply: congr_big => // x; rewrite jump_mod.
 Qed.
 
 Lemma variation0r b : variation 0 b = 0.
-Proof. by rewrite /variation mul0r ltrr mulr0. Qed.
+Proof. by rewrite /variation mul0r ltxx mulr0. Qed.
 
 Lemma variationC a b : variation a b = - variation b a.
 Proof. by rewrite /variation -!sgz_cp0 !sgzM; do 2?case: sgzP => _ //. Qed.
@@ -793,13 +793,13 @@ rewrite roots_cons; case/and5P => _ xab /eqP hax hx /eqP hs.
 rewrite !big_cons variation0r add0r (ihs _ _ hs) ?(itvP xab) // => {ihs}.
 pose y := (head b s); pose ax := midf a x; pose xy := midf x y.
 rewrite (@sjump_neigh a b _ _ _ ax xy) ?inE ?midf_lte//=; last 2 first.
-+ by rewrite /prev_root pq_eq0 hax minr_l ?(itvP xab, midf_lte).
++ by rewrite /prev_root pq_eq0 hax meet_l ?(itvP xab, midf_lte).
 + have hy: y \in `]x, b].
     rewrite /y; case: s hs {y xy} => /= [|u s] hu.
       by rewrite boundr_in_itv /= ?(itvP xab).
     have /roots_in: u \in  roots (p * q) x b by rewrite hu mem_head.
-    by apply: subitvP; rewrite /= !lerr.
-  by rewrite /next_root pq_eq0 hs maxr_l ?(itvP hy, midf_lte).
+    by apply: subitvP; rewrite /= !lexx.
+  by rewrite /next_root pq_eq0 hs join_l ?(itvP hy, midf_lte).
 move: @y @xy {hs}; rewrite /cross.
 by case: s => /= [|y l]; rewrite ?(big_cons, big_nil, variation0r, add0r).
 Qed.
@@ -809,7 +809,7 @@ Lemma cindex_inv a b : a < b -> forall p q,
   cindex a b q p + cindex a b p q = cross (p * q) a b.
 Proof.
 move=> hab p q hpqa hpqb.
-have hlab: a <= b by apply: ltrW.
+have hlab: a <= b by apply: ltW.
 wlog cpq: p q hpqa hpqb / coprimep p q => [hwlog|].
   have p0: p != 0 by apply: contraNneq hpqa => ->; rewrite mul0r rootC.
   have q0: q != 0 by apply: contraNneq hpqa => ->; rewrite mulr0 rootC.
@@ -835,11 +835,11 @@ have pq0 : p * q != 0 by rewrite mulf_neq0.
 rewrite cindex_seq_mids // sum_varP /cross.
   apply: congr_variation; apply: (mulrIz (oner_neq0 R)); rewrite -!sgrEz.
     case hr: roots => [|c s] /=; apply: (@sgr_neighprN _ _ a b) => //;
-    rewrite /neighpr /next_root ?(negPf pq0) maxr_l // hr mid_in_itv //=.
+    rewrite /neighpr /next_root ?(negPf pq0) join_l // hr mid_in_itv //=.
     by move/eqP: hr; rewrite roots_cons => /and5P [_ /itvP ->].
   rewrite -cats1 pairmap_cat /= cats1 map_rcons last_rcons.
   apply: (@sgr_neighplN _ _ a b) => //.
-  rewrite /neighpl /prev_root (negPf pq0) minr_l //.
+  rewrite /neighpl /prev_root (negPf pq0) meet_l //.
   by rewrite mid_in_itv //= last_roots_le.
 elim: roots {-2 6}a (erefl (roots (p * q) a b))
   {hpqa hpqb} hab hlab => {a} [|c s IHs] a Hs hab hlab /=.
@@ -946,7 +946,7 @@ Proof. by rewrite /changes_mods /changes_poly mods0p. Qed.
 Lemma changes_modsp0 p : changes_mods p 0 = 0.
 Proof.
 rewrite /changes_mods /changes_poly modsp0; have [//|p_neq0] := altP eqP.
-by rewrite /changes_minfty /changes_pinfty /= !mulr0 ltrr.
+by rewrite /changes_minfty /changes_pinfty /= !mulr0 ltxx.
 Qed.
 
 Lemma changes_mods_rec p q :
@@ -1000,7 +1000,7 @@ Qed.
 Lemma changes_itv_modsp0 a b p : changes_itv_mods a b p 0 = 0.
 Proof.
 rewrite /changes_itv_mods /changes_itv_poly modsp0 /changes_horner /=.
-by have [//|p_neq0 /=] := altP eqP; rewrite !mulr0 ltrr.
+by have [//|p_neq0 /=] := altP eqP; rewrite !mulr0 ltxx.
 Qed.
 
 Lemma changes_itv_mods_rec a b : a < b -> forall p q,
@@ -1140,7 +1140,7 @@ split=> [|[x]].
   case; last by move=> [x /andP [? h]]; exists x; rewrite h.
     rewrite big_all => /allP hsq.
     have sqn0 : {in sq, forall q, q != 0}.
-      by move=> q' /= /hsq; apply: contraL=> /eqP->; rewrite lead_coef0 ltrr.
+      by move=> q' /= /hsq; apply: contraL=> /eqP->; rewrite lead_coef0 ltxx.
     pose qq := \prod_(q <- sq) q.
     have pn0 : qq != 0.
       by apply/negP=> /myprodf_eq0 [] q; rewrite andbT => /sqn0 /negPf ->.
@@ -1153,7 +1153,7 @@ split=> [|[x]].
   rewrite big_all => /allP hsq.
   have sqn0 : {in sq, forall q, q != 0}.
     move=> q' /= /hsq; apply: contraL=> /eqP->.
-    by rewrite lead_coef0 mulr0 ltrr.
+    by rewrite lead_coef0 mulr0 ltxx.
   pose qq := \prod_(q <- sq) q.
   have pn0 : qq != 0.
     by apply/negP=> /myprodf_eq0 [] q; rewrite andbT => /sqn0 /negPf ->.
@@ -1166,7 +1166,7 @@ split=> [|[x]].
 rewrite /bounding_poly; set q := \prod_(q <- _) _.
 rewrite big_all => /allP hsq; set bnd := cauchy_bound q.
 have sqn0 : {in sq, forall q, q != 0}.
-  by move=> q' /= /hsq; apply: contraL=> /eqP->; rewrite horner0 ltrr.
+  by move=> q' /= /hsq; apply: contraL=> /eqP->; rewrite horner0 ltxx.
 have [/eqP|q_neq0] := eqVneq q 0.
    by rewrite prodf_seq_eq0=> /hasP [q' /= /sqn0 /negPf->].
 have genroot y : {in sq, forall r, ~~ root q y -> ~~ root r y}.
@@ -1179,7 +1179,7 @@ case: (next_rootP q x bnd) q_neq0; [by move->; rewrite eqxx| |]; last first.
   rewrite -sgr_cp0 -/(sgp_pinfty _).
   rewrite -(@sgp_pinftyP _ x _ _ x) ?boundl_in_itv ?sgr_cp0 //.
   move=> z; rewrite (@itv_splitU _ x true) /= ?boundl_in_itv //.
-  rewrite itv_xx /= inE => /orP [/eqP->|]; first by rewrite /root gtr_eqF.
+  rewrite itv_xx /= inE => /orP [/eqP->|]; first by rewrite /root gt_eqF.
   have [x_b|b_x] := ltrP x bnd.
     rewrite (@itv_splitU _ bnd false) /=; last by rewrite inE /= x_b.
     move=> /orP [] Hz; rewrite genroot //;
@@ -1194,7 +1194,7 @@ case: (prev_rootP q (- bnd) x); [by move->; rewrite eqxx| |]; last first.
   rewrite -sgr_cp0 -/(sgp_minfty _).
   rewrite -(@sgp_minftyP _ x _ _ x) ?boundr_in_itv ?sgr_cp0 //.
   move=> z; rewrite (@itv_splitU _ x false) /= ?boundr_in_itv //.
-  rewrite itv_xx => /orP [/=|/eqP->]; last by rewrite /root gtr_eqF.
+  rewrite itv_xx => /orP [/=|/eqP->]; last by rewrite /root gt_eqF.
   have [b_x|x_b] := ltrP (- bnd) x.
     rewrite (@itv_splitU _ (- bnd) true) /=; last by rewrite inE /= b_x.
     move=> /orP [] Hz; rewrite genroot //;
@@ -1202,14 +1202,14 @@ case: (prev_rootP q (- bnd) x); [by move->; rewrite eqxx| |]; last first.
   by move=> Hz; rewrite genroot // le_cauchy_bound // (subitvP _ Hz) //= x_b.
 move=> y2 _ rqy2 hy2xb hy2 q_neq0.
 have lty12 : y2 < y1.
-  by apply: (@ltr_trans _ x); rewrite 1?(itvP hy1xb) 1?(itvP hy2xb).
+  by apply: lt_trans (_ : x < _); rewrite 1?(itvP hy1xb) 1?(itvP hy2xb).
 have : q.[y2] = q.[y1] by rewrite rqy1 rqy2.
 case/(rolle lty12) => z hz rz; constructor 3; exists z.
 rewrite rz eqxx /= big_all; apply/allP => r r_sq.
 have xy : x \in `]y2, y1[ by rewrite inE /= 1?(itvP hy1xb) 1?(itvP hy2xb).
 rewrite -sgr_cp0 (@polyrN0_itv _ `]y2, y1[ _ _ x) ?sgr_cp0 ?hsq // => t.
 rewrite (@itv_splitU2 _ x) // => /or3P [/hy2|/eqP->|/hy1]; do ?exact: genroot.
-by rewrite rootE gtr_eqF ?hsq.
+by rewrite rootE gt_eqF ?hsq.
 Qed.
 
 Lemma size_prod_eq1 (sq : seq {poly R}) :
@@ -1265,7 +1265,7 @@ apply: (@equivP (exists x, \big[andb/true]_(q <- sq) (0 < q.[x]))); last first.
 have [|bq_neq0] := boolP (bounding_poly sq == 0).
   rewrite /bounding_poly -derivn1 -derivn_poly0 => ssq_le1.
   rewrite -constraints1P (size1_polyC ssq_le1) derivnC /= rootsRC.
-  rewrite /constraints big_nil ltrr orbF.
+  rewrite /constraints big_nil ltxx orbF.
   move: ssq_le1; rewrite leq_eqVlt ltnS leqn0 orbC.
   have [|_ /=] := boolP (_ == _).
     rewrite size_poly_eq0 => /eqP sq_eq0; move/eqP: (sq_eq0).
@@ -1273,10 +1273,10 @@ have [|bq_neq0] := boolP (bounding_poly sq == 0).
     move: q_sq; rewrite q_eq0 => sq0 _ {q q_eq0}.
     set f := _ || _; suff -> : f = false; move: @f => /=.
       constructor => [] [x]; rewrite big_all.
-      by move=> /allP /(_ _ sq0); rewrite horner0 ltrr.
+      by move=> /allP /(_ _ sq0); rewrite horner0 ltxx.
     apply: negbTE; rewrite !negb_or !big_all -!has_predC.
     apply/andP; split; apply/hasP;
-    by exists 0; rewrite //= ?lead_coef0 ?mulr0 ltrr.
+    by exists 0; rewrite //= ?lead_coef0 ?mulr0 ltxx.
   move=> /size_prod_eq1 Hsq.
   have {Hsq} Hsq q : q \in sq -> q = (lead_coef q)%:P.
     by move=> /Hsq sq1; rewrite [q]size1_polyC ?sq1 // lead_coefC.

--- a/theories/realalg.v
+++ b/theories/realalg.v
@@ -194,11 +194,11 @@ Definition eq_algcreal : rel algcreal := eq_algcreal_dec.
 
 Lemma eq_algcrealP (x y : algcreal) : reflect (x == y)%CR (eq_algcreal x y).
 Proof. by rewrite /eq_algcreal; case: eq_algcreal_dec=> /=; constructor. Qed.
-Arguments eq_algcrealP [x y].
+Arguments eq_algcrealP {x y}.
 
 Lemma neq_algcrealP (x y : algcreal) : reflect (x != y)%CR (~~ eq_algcreal x y).
 Proof. by rewrite /eq_algcreal; case: eq_algcreal_dec=> /=; constructor. Qed.
-Arguments neq_algcrealP [x y].
+Arguments neq_algcrealP {x y}.
 Prenex Implicits eq_algcrealP neq_algcrealP.
 
 Fact eq_algcreal_is_equiv : equiv_class_of eq_algcreal.
@@ -284,11 +284,11 @@ Definition le_algcreal : rel algcreal := fun x y => ~~ ltVge_algcreal_dec y x.
 
 Lemma lt_algcrealP (x y : algcreal) : reflect (x < y)%CR (lt_algcreal x y).
 Proof. by rewrite /lt_algcreal; case: ltVge_algcreal_dec; constructor. Qed.
-Arguments lt_algcrealP [x y].
+Arguments lt_algcrealP {x y}.
 
 Lemma le_algcrealP (x y : algcreal) : reflect (x <= y)%CR (le_algcreal x y).
 Proof. by rewrite /le_algcreal; case: ltVge_algcreal_dec; constructor. Qed.
-Arguments le_algcrealP [x y].
+Arguments le_algcrealP {x y}.
 Prenex Implicits lt_algcrealP le_algcrealP.
 
 Definition exp_algcreal x n := iterop n mul_algcreal x one_algcreal.
@@ -609,7 +609,7 @@ Qed.
 
 Lemma nequiv_alg (x y : algcreal) : reflect (x != y)%CR (x != y %[mod {alg F}]).
 Proof. by rewrite eqquotE; apply: neq_algcrealP. Qed.
-Arguments nequiv_alg [x y].
+Arguments nequiv_alg {x y}.
 Prenex Implicits nequiv_alg.
 
 Lemma pi_algK (x : algcreal) : (repr (\pi_{alg F} x) == x)%CR.
@@ -711,7 +711,7 @@ elim/quotW=> x; elim/quotW=> y; elim/quotW=> z; rewrite !piE -equiv_alg /=.
 by apply: eq_crealP; exists m0=> * /=; rewrite mulrDl subrr normr0.
 Qed.
 
-Arguments neq_creal_cst [F x y].
+Arguments neq_creal_cst {F x y}.
 Prenex Implicits neq_creal_cst.
 
 Lemma nonzero1_alg : one_alg != zero_alg.
@@ -971,11 +971,11 @@ Proof. by rewrite [`|_|]piE. Qed.
 
 Lemma lt_algP (x y : algcreal) : reflect (x < y)%CR (\pi_{alg F} x < \pi y).
 Proof. by rewrite lt_pi; apply: lt_algcrealP. Qed.
-Arguments lt_algP [x y].
+Arguments lt_algP {x y}.
 
 Lemma le_algP (x y : algcreal) : reflect (x <= y)%CR (\pi_{alg F} x <= \pi y).
 Proof. by rewrite le_pi; apply: le_algcrealP. Qed.
-Arguments le_algP [x y].
+Arguments le_algP {x y}.
 Prenex Implicits lt_algP le_algP.
 
 Lemma ler_to_alg : {mono to_alg : x y / x <= y}.

--- a/theories/realalg.v
+++ b/theories/realalg.v
@@ -943,10 +943,11 @@ Qed.
 Definition AlgNumFieldMixin := RealLtMixin add_alg_gt0 mul_alg_gt0
   gt0_alg_nlt0 sub_alg_gt0 lt0_alg_total norm_algN ge0_norm_alg le_alg_def.
 Canonical alg_porderType := POrderType ring_display alg AlgNumFieldMixin.
+Canonical alg_latticeType := LatticeType alg AlgNumFieldMixin.
 Canonical alg_distrLatticeType := DistrLatticeType alg AlgNumFieldMixin.
 Canonical alg_orderType := OrderType alg AlgNumFieldMixin.
 Canonical alg_numDomainType := NumDomainType alg AlgNumFieldMixin.
-Canonical alg_normedZmodType := NormedZmoduleType alg alg AlgNumFieldMixin.
+Canonical alg_normedZmodType := NormedZmodType alg alg AlgNumFieldMixin.
 Canonical alg_numFieldType := [numFieldType of alg].
 Canonical alg_of_porderType := [porderType of {alg F}].
 Canonical alg_of_distrLatticeType := [distrLatticeType of {alg F}].

--- a/theories/realalg.v
+++ b/theories/realalg.v
@@ -4,7 +4,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp
 Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp
-Require Import bigop ssralg ssrnum ssrint rat poly polydiv polyorder.
+Require Import bigop order ssralg ssrnum ssrint rat poly polydiv polyorder.
 From mathcomp
 Require Import perm matrix mxpoly polyXY binomial generic_quotient.
 From mathcomp
@@ -22,7 +22,7 @@ Require Import cauchyreals separable zmodp bigenough.
 (* field R (for which rat is a prefect candidate)                        *)
 (*************************************************************************)
 
-Import GRing.Theory Num.Theory BigEnough.
+Import Order.TTheory GRing.Theory Num.Theory BigEnough.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -319,13 +319,13 @@ Proof.
 rewrite /norm_algcreal /le_algcreal; case: ltVge_algcreal_dec => /=.
   move=> x_lt0; apply: eq_crealP; exists_big_modulus m F.
     move=> e i e_gt0 hi /=; rewrite [`|x i|]ler0_norm ?subrr ?normr0 //.
-    by rewrite ltrW // [_ < 0%CR i]creal_lt_always.
+    by rewrite ltW // [_ < 0%CR i]creal_lt_always.
   by close.
 move=> /(@le_creal_neqVlt zero_algcreal) /= [].
   by move<-; apply: eq_crealP; exists m0=> * /=; rewrite !(normr0, subrr).
 move=> x_gt0; apply: eq_crealP; exists_big_modulus m F.
   move=> e i e_gt0 hi /=; rewrite [`|x i|]ger0_norm ?subrr ?normr0 //.
-  by rewrite ltrW // creal_gt0_always.
+  by rewrite ltW // creal_gt0_always.
 by close.
 Qed.
 
@@ -404,15 +404,15 @@ Lemma to_algcreal_ofP p c r i j : 0 <= r -> (i <= j)%N ->
   `|to_algcreal_of p c r j - to_algcreal_of p c r i| <= r * 2%:R ^- i.
 Proof.
 move=> r_ge0 leij; pose r' := r * 2%:R ^- j * (2%:R ^+ (j - i) - 1).
-rewrite (@ler_trans _ r') //; last first.
+apply: le_trans (_ : r' <= _); last first.
   rewrite /r' -mulrA ler_wpmul2l // ler_pdivr_mull ?exprn_gt0 ?ltr0n //.
-  rewrite -{2}(subnK leij) exprD mulfK ?gtr_eqF ?exprn_gt0 ?ltr0n //.
+  rewrite -{2}(subnK leij) exprD mulfK ?gt_eqF ?exprn_gt0 ?ltr0n //.
   by rewrite ger_addl lerN10.
 rewrite /r' subrX1 addrK mul1r -{1 2}(subnK leij); set f := _  c r.
-elim: (_ - _)%N=> [|k ihk]; first by rewrite subrr normr0 big_ord0 mulr0 lerr.
+elim: (_ - _)%N=> [|k ihk]; first by rewrite subrr normr0 big_ord0 mulr0 lexx.
 rewrite addSn big_ord_recl /= mulrDr.
-rewrite (ler_trans (ler_dist_add (f (k + i)%N) _ _)) //.
-rewrite ler_add ?expr0 ?mulr1 ?to_algcreal_of_recP // (ler_trans ihk) //.
+rewrite (le_trans (ler_dist_add (f (k + i)%N) _ _)) //.
+rewrite ler_add ?expr0 ?mulr1 ?to_algcreal_of_recP // (le_trans ihk) //.
 rewrite exprSr invfM -!mulrA !ler_wpmul2l ?invr_ge0 ?exprn_ge0 ?ler0n //.
 by rewrite mulr_sumr ler_sum // => l _ /=; rewrite exprS mulKf ?pnatr_eq0.
 Qed.
@@ -425,7 +425,7 @@ pose_big_modulus m F.
   wlog leij : i j {hi} hj / (j <= i)%N.
     move=> hwlog; case/orP: (leq_total i j)=> /hwlog; last exact.
     by rewrite distrC; apply.
-  rewrite (ler_lt_trans (to_algcreal_ofP _ _ _ _)) ?radius_alg_ge0 //.
+  rewrite (le_lt_trans (to_algcreal_ofP _ _ _ _)) ?radius_alg_ge0 //.
   rewrite ltr_pdivr_mulr ?gtr0E // -ltr_pdivr_mull //.
   by rewrite upper_nthrootP.
 by close.
@@ -443,8 +443,8 @@ pose_big_modulus m F.
   rewrite ger0_norm ?subr_ge0; last first.
     by rewrite ?lef_pinv -?topredE /= ?gtr0E // ler_eexpn2l ?ltr1n.
   rewrite -(@ltr_pmul2l _ (2%:R ^+ i )) ?gtr0E //.
-  rewrite mulrBr mulfV ?gtr_eqF ?gtr0E //.
-  rewrite (@ler_lt_trans _ 1) // ?ger_addl ?oppr_le0 ?mulr_ge0 ?ger0E //.
+  rewrite mulrBr mulfV ?gt_eqF ?gtr0E //.
+  rewrite (le_lt_trans (_ : _ <= 1)) // ?ger_addl ?oppr_le0 ?mulr_ge0 ?ger0E //.
   by rewrite -ltr_pdivr_mulr // mul1r upper_nthrootP.
 by close.
 Qed.
@@ -486,7 +486,7 @@ pose_big_enough i.
   rewrite add0r [u]lock /= -!expr2.
   rewrite -[_.[_] ^+ _]ger0_norm ?exprn_even_ge0 // normrX.
   rewrite ler_pexpn2r -?topredE /= ?lbound_ge0 ?normr_ge0 //.
-  by rewrite -lock (ler_trans _ (lbound0_of pu0)).
+  by rewrite -lock (le_trans _ (lbound0_of pu0)).
 by close.
 Qed.
 
@@ -517,8 +517,8 @@ have [|ncop] := boolP (coprimep p p^`()).
           suff:  p.[x i - r] <= p.[x j] <= p.[x i + r] by case/andP=> -> ->.
         rewrite !hp 1?addrAC ?subrr ?add0r ?normrN;
         rewrite ?(gtr0_norm r_gt0) //;
-          do ?by rewrite ltrW ?cauchymodP ?(leq_trans _ hj).
-        by rewrite -ler_distl ltrW ?cauchymodP ?(leq_trans _ hj).
+          do ?by rewrite ltW ?cauchymodP ?(leq_trans _ hj).
+        by rewrite -ler_distl ltW ?cauchymodP ?(leq_trans _ hj).
       rewrite mulr_le0_ge0 //; apply/le_creal_cst; rewrite -px0;
       by apply: (@le_crealP _ i)=> h hj /=; rewrite hpxj.
     have hpxj : forall j, (i <= j)%N ->
@@ -527,11 +527,11 @@ have [|ncop] := boolP (coprimep p p^`()).
         suff:  p.[x i + r] <= p.[x j] <= p.[x i - r] by case/andP=> -> ->.
       rewrite !hp 1?addrAC ?subrr ?add0r ?normrN;
       rewrite ?(gtr0_norm r_gt0) //;
-        do ?by rewrite ltrW ?cauchymodP ?(leq_trans _ hj).
-      by rewrite andbC -ler_distl ltrW ?cauchymodP ?(leq_trans _ hj).
+        do ?by rewrite ltW ?cauchymodP ?(leq_trans _ hj).
+      by rewrite andbC -ler_distl ltW ?cauchymodP ?(leq_trans _ hj).
     rewrite mulr_ge0_le0 //; apply/le_creal_cst; rewrite -px0;
     by apply: (@le_crealP _ i)=> h hj /=; rewrite hpxj.
-  pose y := (AlgDom (monic_annul_creal x) (ltrW r_gt0) p_chg_sign).
+  pose y := (AlgDom (monic_annul_creal x) (ltW r_gt0) p_chg_sign).
   have eq_py_px: (p.[to_algcreal y] == p.[x])%CR.
     rewrite /to_algcreal -lock.
     by have := @to_algcrealP y; rewrite /= -/p=> ->; apply: eq_creal_sym.
@@ -539,11 +539,11 @@ have [|ncop] := boolP (coprimep p p^`()).
   move: sm=> /strong_mono_bound [k k_gt0 hk].
   rewrite -/p; apply: eq_crealP.
   exists_big_modulus m F.
-    move=> e j e_gt0 hj; rewrite (ler_lt_trans (hk _ _ _ _)) //.
+    move=> e j e_gt0 hj; rewrite (le_lt_trans (hk _ _ _ _)) //.
     + rewrite /to_algcreal -lock.
-      rewrite (ler_trans (to_algcreal_ofP _ _ _ (leq0n _))) ?(ltrW r_gt0) //.
+      rewrite (le_trans (to_algcreal_ofP _ _ _ (leq0n _))) ?(ltW r_gt0) //.
       by rewrite expr0 divr1.
-    + by rewrite ltrW // cauchymodP.
+    + by rewrite ltW // cauchymodP.
     rewrite -ltr_pdivl_mull //.
     by rewrite (@eq_modP _ _ _ eq_py_px) // ?pmulr_rgt0 ?invr_gt0.
   by close.
@@ -876,9 +876,9 @@ rewrite -[x]reprK -[y]reprK !piE -!(rwP lt_algcrealP).
 move=> x_gt0 y_gt0; pose_big_enough i.
   apply: (@lt_crealP _ (diff x_gt0 * diff y_gt0) i i) => //.
     by rewrite pmulr_rgt0 ?diff_gt0.
-  rewrite /= add0r (@ler_trans _ (diff x_gt0 * (repr y) i)) //.
-    by rewrite ler_wpmul2l ?(ltrW (diff_gt0 _)) // diff0P.
-  by rewrite ler_wpmul2r ?diff0P ?ltrW ?creal_gt0_always.
+  rewrite /= add0r (le_trans (_ : _ <= diff x_gt0 * (repr y) i)) //.
+    by rewrite ler_wpmul2l ?(ltW (diff_gt0 _)) // diff0P.
+  by rewrite ler_wpmul2r ?diff0P ?ltW ?creal_gt0_always.
 by close.
 Qed.
 
@@ -887,7 +887,7 @@ Proof.
 rewrite -[x]reprK !piE -!(rwP lt_algcrealP, rwP le_algcrealP).
 move=> hx; pose_big_enough i.
   apply: (@le_crealP _ i)=> j /= hj.
-  by rewrite ltrW // creal_gt0_always.
+  by rewrite ltW // creal_gt0_always.
 by close.
 Qed.
 
@@ -932,9 +932,9 @@ Proof. by rewrite -sub0r sub_alg_gt0. Qed.
 Lemma lt_alg00 : lt_alg zero_alg zero_alg = false.
 Proof. by have /implyP := @gt0_alg_nlt0 0; case: lt_alg. Qed.
 
-Lemma le_alg_def x y : le_alg x y = (y == x) || lt_alg x y.
+Lemma le_alg_def x y : le_alg x y = (x == y) || lt_alg x y.
 Proof.
-rewrite -[x]reprK -[y]reprK eq_sym piE [lt_alg _ _]piE; apply/le_algcrealP/orP.
+rewrite -[x]reprK -[y]reprK piE [lt_alg _ _]piE; apply/le_algcrealP/orP.
   move=> /le_creal_neqVlt [/eq_algcrealP/eqquotP/eqP-> //|lt_xy]; first by left.
   by right; apply/lt_algcrealP.
 by move=> [/eqP/eqquotP/eq_algcrealP-> //| /lt_algcrealP /lt_crealW].
@@ -942,13 +942,19 @@ Qed.
 
 Definition AlgNumFieldMixin := RealLtMixin add_alg_gt0 mul_alg_gt0
   gt0_alg_nlt0 sub_alg_gt0 lt0_alg_total norm_algN ge0_norm_alg le_alg_def.
+Canonical alg_porderType := POrderType ring_display alg AlgNumFieldMixin.
+Canonical alg_distrLatticeType := DistrLatticeType alg AlgNumFieldMixin.
+Canonical alg_orderType := OrderType alg AlgNumFieldMixin.
 Canonical alg_numDomainType := NumDomainType alg AlgNumFieldMixin.
+Canonical alg_normedZmodType := NormedZmoduleType alg alg AlgNumFieldMixin.
 Canonical alg_numFieldType := [numFieldType of alg].
+Canonical alg_of_porderType := [porderType of {alg F}].
+Canonical alg_of_distrLatticeType := [distrLatticeType of {alg F}].
+Canonical alg_of_orderType := [orderType of {alg F}].
 Canonical alg_of_numDomainType := [numDomainType of {alg F}].
+Canonical alg_of_normedZmodType := [normedZmodType {alg F} of {alg F}].
 Canonical alg_of_numFieldType := [numFieldType of {alg F}].
-
-Definition AlgRealFieldMixin := RealLeAxiom alg.
-Canonical alg_realDomainType := RealDomainType alg AlgRealFieldMixin.
+Canonical alg_realDomainType := [realDomainType of alg].
 Canonical alg_realFieldType := [realFieldType of alg].
 Canonical alg_of_realDomainType := [realDomainType of {alg F}].
 Canonical alg_of_realFieldType := [realFieldType of {alg F}].
@@ -973,19 +979,19 @@ Prenex Implicits lt_algP le_algP.
 
 Lemma ler_to_alg : {mono to_alg : x y / x <= y}.
 Proof.
-apply: ler_mono=> x y lt_xy; rewrite !piE -(rwP lt_algP).
+apply: le_mono=> x y lt_xy; rewrite !piE -(rwP lt_algP).
 by apply/lt_creal_cst; rewrite lt_xy.
 Qed.
 
 Lemma ltr_to_alg : {mono to_alg : x y / x < y}.
-Proof. by apply: lerW_mono; apply: ler_to_alg. Qed.
+Proof. by apply: leW_mono; apply: ler_to_alg. Qed.
 
 Lemma normr_to_alg : { morph to_alg : x / `|x| }.
 Proof.
 move=> x /=; have [] := ger0P; have [] := ger0P x%:RA;
   rewrite ?rmorph0 ?rmorphN ?oppr0 //=.
-  by rewrite ltr_to_alg lerNgt => ->.
-by rewrite ler_to_alg ltrNge => ->.
+  by rewrite ltr_to_alg leNgt => ->.
+by rewrite ler_to_alg ltNge => ->.
 Qed.
 
 Lemma inf_alg_proof x : {d | 0 < d & 0 < x -> (d%:RA < x)}.
@@ -1012,13 +1018,13 @@ Proof. by rewrite /inf_alg=> x_gt0; case: inf_alg_proof=> d _ /(_ x_gt0). Qed.
 Lemma approx_proof x e : {y | 0 < e -> `|x - y%:RA| < e}.
 Proof.
 elim/quotW:x => x; pose_big_enough i.
-  exists (x i)=> e_gt0; rewrite (ltr_trans _ (inf_lt_alg _)) //.
+  exists (x i)=> e_gt0; rewrite (lt_trans _ (inf_lt_alg _)) //.
   rewrite !piE sub_pi norm_pi -(rwP lt_algP) /= norm_algcrealE /=.
   pose_big_enough j.
     apply: (@lt_crealP  _ (inf_alg e / 2%:R) j j) => //.
       by rewrite pmulr_rgt0 ?gtr0E ?inf_alg_gt0.
     rewrite /= {2}[inf_alg e](splitf 2) /= ler_add2r.
-    by rewrite ltrW // cauchymodP ?pmulr_rgt0 ?gtr0E ?inf_alg_gt0.
+    by rewrite ltW // cauchymodP ?pmulr_rgt0 ?gtr0E ?inf_alg_gt0.
   by close.
 by close.
 Qed.
@@ -1028,7 +1034,7 @@ Definition approx := locked
 
 Lemma approxP (x e e': alg) : 0 < e -> e <= e' -> `|x - (approx x e)%:RA| < e'.
 Proof.
-by unlock approx; case: approx_proof=> /= y hy /hy /ltr_le_trans hy' /hy'.
+by unlock approx; case: approx_proof=> /= y hy /hy /lt_le_trans hy' /hy'.
 Qed.
 
 Lemma alg_archi : Num.archimedean_axiom alg_of_numDomainType.
@@ -1036,9 +1042,9 @@ Proof.
 move=> x; move: {x}`|x| (normr_ge0 x) => x x_ge0.
 pose a := approx x 1%:RA; exists (Num.bound (a + 1)).
 have := @archi_boundP _ (a + 1); rewrite -ltr_to_alg rmorph_nat.
-have := @approxP x _ _ ltr01 (lerr _); rewrite ltr_distl -/a => /andP [_ hxa].
-rewrite -ler_to_alg rmorphD /= (ler_trans _ (ltrW hxa)) //.
-by move=> /(_ isT) /(ltr_trans _)->.
+have := @approxP x _ _ ltr01 (lexx _); rewrite ltr_distl -/a => /andP [_ hxa].
+rewrite -ler_to_alg rmorphD /= (le_trans _ (ltW hxa)) //.
+by move=> /(_ isT) /(lt_trans _)->.
 Qed.
 
 Canonical alg_archiFieldType := ArchiFieldType alg alg_archi.
@@ -1057,7 +1063,7 @@ Lemma weak_ivt (p : {poly F}) (a b : F) : a <= b -> p.[a] <= 0 <= p.[b] ->
   { x : alg | a%:RA <= x <= b%:RA & root (p ^ to_alg) x }.
 Proof.
 move=> le_ab; have [->  _|p_neq0] := eqVneq p 0.
-  by exists a%:RA; rewrite ?lerr ?ler_to_alg // rmorph0 root0.
+  by exists a%:RA; rewrite ?lexx ?ler_to_alg // rmorph0 root0.
 move=> /andP[pa_le0 pb_ge0]; apply/sig2W.
 have hpab: p.[a] * p.[b] <= 0 by rewrite mulr_le0_ge0.
 move=> {pa_le0 pb_ge0}; wlog monic_p : p hpab p_neq0 / p \is monic.
@@ -1261,10 +1267,10 @@ Proof.
 exists_big_modulus m {alg {alg F}}.
   move=> e i e_gt0 hi; rewrite distrC /approx2.
   rewrite (@split_dist_add _ (approx x (2%:R ^- i))%:RA) //.
-    rewrite approxP ?gtr0E // ltrW //.
+    rewrite approxP ?gtr0E // ltW //.
     by rewrite upper_nthrootVP ?divrn_gt0 ?ltr_to_alg.
-  rewrite (ltr_trans _ (inf_lt_alg _)) ?divrn_gt0 //.
-  rewrite -rmorphB -normr_to_alg ltr_to_alg approxP ?gtr0E // ltrW //.
+  rewrite (lt_trans _ (inf_lt_alg _)) ?divrn_gt0 //.
+  rewrite -rmorphB -normr_to_alg ltr_to_alg approxP ?gtr0E // ltW //.
   by rewrite upper_nthrootVP ?divrn_gt0 ?inf_alg_gt0 ?ltr_to_alg.
 by close.
 Qed.
@@ -1284,7 +1290,7 @@ Lemma to_alg_crealP (x : creal F) :  creal_axiom (fun i => to_alg F (x i)).
 Proof.
 exists_big_modulus m (alg F).
   move=> e i j e_gt0 hi hj.
-  rewrite -rmorphB -normr_to_alg (ltr_trans _ (inf_lt_alg _)) //.
+  rewrite -rmorphB -normr_to_alg (lt_trans _ (inf_lt_alg _)) //.
   by rewrite ltr_to_alg cauchymodP ?inf_alg_gt0.
 by close.
 Qed.
@@ -1303,8 +1309,8 @@ split=> neq_xy.
   pose_big_enough i.
     apply: (@neq_crealP _ (inf_alg (lbound neq_xy)) i i) => //.
       by rewrite inf_alg_gt0.
-    rewrite -ler_to_alg normr_to_alg rmorphB /= ltrW //.
-    by rewrite (ltr_le_trans (inf_lt_alg _)) ?lbound_gt0 ?lboundP.
+    rewrite -ler_to_alg normr_to_alg rmorphB /= ltW //.
+    by rewrite (lt_le_trans (inf_lt_alg _)) ?lbound_gt0 ?lboundP.
   by close.
 pose_big_enough i.
   apply: (@neq_crealP _ (lbound neq_xy)%:RA i i) => //.
@@ -1330,11 +1336,11 @@ Global Existing Instance to_alg_creal_morph_Proper.
 Lemma to_alg_creal_repr (x : {alg F}) : (to_alg_creal (repr x) == x%:CR)%CR.
 Proof.
 apply: eq_crealP; exists_big_modulus m {alg F}.
-  move=> e i e_gt0 hi /=; rewrite (ler_lt_trans _ (inf_lt_alg _)) //.
+  move=> e i e_gt0 hi /=; rewrite (le_lt_trans _ (inf_lt_alg _)) //.
   rewrite -{2}[x]reprK !piE sub_pi norm_pi.
   rewrite -(rwP (le_algP _ _)) norm_algcrealE /=; pose_big_enough j.
     apply: (@le_crealP _ j)=> k hk /=.
-    by rewrite ltrW // cauchymodP ?inf_alg_gt0.
+    by rewrite ltW // cauchymodP ?inf_alg_gt0.
   by close.
 by close.
 Qed.
@@ -1344,12 +1350,12 @@ Local Open Scope quotient_scope.
 Lemma cst_pi (x : algcreal F) : ((\pi_{alg F} x)%:CR == to_alg_creal x)%CR.
 Proof.
 apply: eq_crealP; exists_big_modulus m {alg F}.
-  move=> e i e_gt0 hi /=; rewrite (ltr_trans _ (inf_lt_alg _)) //.
+  move=> e i e_gt0 hi /=; rewrite (lt_trans _ (inf_lt_alg _)) //.
   rewrite !piE sub_pi norm_pi /= -(rwP (lt_algP _ _)) norm_algcrealE /=.
   pose_big_enough j.
     apply: (@lt_crealP _ (inf_alg e / 2%:R) j j) => //.
       by rewrite ?divrn_gt0 ?inf_alg_gt0.
-    rewrite /= {2}[inf_alg _](splitf 2) ler_add2r ltrW // distrC.
+    rewrite /= {2}[inf_alg _](splitf 2) ler_add2r ltW // distrC.
     by rewrite cauchymodP ?divrn_gt0 ?inf_alg_gt0.
   by close.
 by close.
@@ -1448,7 +1454,11 @@ Canonical RealAlg.alg_unitRing.
 Canonical RealAlg.alg_comUnitRing.
 Canonical RealAlg.alg_iDomain.
 Canonical RealAlg.alg_fieldType.
+Canonical RealAlg.alg_porderType.
+Canonical RealAlg.alg_distrLatticeType.
+Canonical RealAlg.alg_orderType.
 Canonical RealAlg.alg_numDomainType.
+Canonical RealAlg.alg_normedZmodType.
 Canonical RealAlg.alg_numFieldType.
 Canonical RealAlg.alg_realDomainType.
 Canonical RealAlg.alg_realFieldType.
@@ -1464,7 +1474,11 @@ Canonical RealAlg.alg_of_unitRing.
 Canonical RealAlg.alg_of_comUnitRing.
 Canonical RealAlg.alg_of_iDomain.
 Canonical RealAlg.alg_of_fieldType.
+Canonical RealAlg.alg_of_porderType.
+Canonical RealAlg.alg_of_distrLatticeType.
+Canonical RealAlg.alg_of_orderType.
 Canonical RealAlg.alg_of_numDomainType.
+Canonical RealAlg.alg_of_normedZmodType.
 Canonical RealAlg.alg_of_numFieldType.
 Canonical RealAlg.alg_of_realDomainType.
 Canonical RealAlg.alg_of_realFieldType.
@@ -1508,7 +1522,11 @@ Canonical realalg_unitRingType := [unitRingType of realalg].
 Canonical realalg_comUnitRingType := [comUnitRingType of realalg].
 Canonical realalg_idomainType := [idomainType of realalg].
 Canonical realalg_fieldTypeType := [fieldType of realalg].
+Canonical realalg_porderType := [porderType of realalg].
+Canonical realalg_distrLatticeType := [distrLatticeType of realalg].
+Canonical realalg_orderType := [orderType of realalg].
 Canonical realalg_numDomainType := [numDomainType of realalg].
+Canonical realalg_normedZmodType := [normedZmodType realalg of realalg].
 Canonical realalg_numFieldType := [numFieldType of realalg].
 Canonical realalg_realDomainType := [realDomainType of realalg].
 Canonical realalg_realFieldType := [realFieldType of realalg].


### PR DESCRIPTION
This can be compiled with https://github.com/math-comp/math-comp/pull/270 without the compatibility module `ssrnum.mc_1_9`.