### PR TITLE
Adapt to math-comp' PR #923

### DIFF
--- a/theories/complex.v
+++ b/theories/complex.v
@@ -508,7 +508,7 @@ rewrite [_ +i* _]complexE.
 apply: integral_add => //; apply: integral_mul => //=.
 exists ('X^2 + 1).
   by rewrite monicE lead_coefDl ?size_polyXn ?size_poly1 ?lead_coefXn.
-by rewrite rmorphD rmorph1 /= ?map_polyXn rootE !hornerE -expr2 sqr_i addNr.
+by rewrite rmorphD rmorph1 /= ?map_polyXn rootE !hornerE sqr_i addNr.
 Qed.
 
 Lemma normc_def (z : R[i]) : `|z| = (sqrtr ((Re z)^+2 + (Im z)^+2))%:C.

--- a/theories/complex.v
+++ b/theories/complex.v
@@ -508,7 +508,7 @@ rewrite [_ +i* _]complexE.
 apply: integral_add => //; apply: integral_mul => //=.
 exists ('X^2 + 1).
   by rewrite monicE lead_coefDl ?size_polyXn ?size_poly1 ?lead_coefXn.
-by rewrite rmorphD rmorph1 /= ?map_polyXn rootE !hornerE sqr_i addNr.
+by rewrite rmorphD rmorph1 /= ?map_polyXn rootE !hornerE -?expr2 sqr_i addNr.
 Qed.
 
 Lemma normc_def (z : R[i]) : `|z| = (sqrtr ((Re z)^+2 + (Im z)^+2))%:C.

--- a/theories/polyorder.v
+++ b/theories/polyorder.v
@@ -193,7 +193,7 @@ rewrite mu_exp mu_XsubC mul1n [\mu_x qqp]muNroot // add0n.
 rewrite exprD mulrA -mulrDl mu_mul; last first.
   by rewrite mulrDl -mulrA -exprD subnK 1?ltnW // -hp -hq.
 rewrite muNroot ?add0n ?mu_exp ?mu_XsubC ?mul1n //.
-rewrite rootE !hornerE horner_exp hornerXsubC subrr.
+rewrite rootE !hornerE subrr.
 by rewrite -subnSK // subnS exprS mul0r mulr0 addr0.
 Qed.
 

--- a/theories/polyorder.v
+++ b/theories/polyorder.v
@@ -193,7 +193,7 @@ rewrite mu_exp mu_XsubC mul1n [\mu_x qqp]muNroot // add0n.
 rewrite exprD mulrA -mulrDl mu_mul; last first.
   by rewrite mulrDl -mulrA -exprD subnK 1?ltnW // -hp -hq.
 rewrite muNroot ?add0n ?mu_exp ?mu_XsubC ?mul1n //.
-rewrite rootE !hornerE subrr.
+rewrite rootE !hornerE ?horner_exp ?hornerXsubC subrr.
 by rewrite -subnSK // subnS exprS mul0r mulr0 addr0.
 Qed.
 


### PR DESCRIPTION
This branch is supposed to do what is in the title ; notice there's a first commit doing the change and then a second so that the proofs stay compatible with both versions.